### PR TITLE
回测前推行情获取及指数分钟回测问题

### DIFF
--- a/QUANTAXIS/QABacktest/QABacktest.py
+++ b/QUANTAXIS/QABacktest/QABacktest.py
@@ -184,7 +184,8 @@ class QA_Backtest():
 
         elif self.backtest_type in ['index_1min', 'index_5min', 'index_15min', 'index_30min', 'index_60min']:
             self.market_data = QA_fetch_index_min_adv(
-                self.strategy_stock_list, self.start_real_date, self.end_real_date, self.backtest_type.split('_')[1])
+                self.strategy_stock_list, self.trade_list[self.start_real_id - int(
+                    self.strategy_gap)], self.trade_list[self.end_real_id + 1], self.backtest_type.split('_')[1])
 
     def __QA_backtest_start(self, *args, **kwargs):
         """

--- a/QUANTAXIS/QAData/QADataStruct.py
+++ b/QUANTAXIS/QAData/QADataStruct.py
@@ -149,17 +149,17 @@ class stock_hq_base(__stock_base):
         elif method in ['lt', '<']:
             def __lt(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] < time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] < time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] < time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] < time].tail(gap).set_index(['datetime', 'code'], drop=False)
                 
             return self.sync_status(stock_hq_base(pd.concat(list(map(lambda x: __lt(x), self.splits())))))
         elif method in ['lte', '<=']:
             def __lte(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] <= time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] <= time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] <= time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] <= time].tail(gap).set_index(['datetime', 'code'], drop=False)
             return self.sync_status(stock_hq_base(pd.concat(list(map(lambda x: __lte(x), self.splits())))))
         elif method in ['e', '==', '=', 'equal']:
             def __eq(__dataS):
@@ -279,17 +279,17 @@ class QA_DataStruct_Index_day(stock_hq_base):
         elif method in ['lt', '<']:
             def __lt(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] < time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] < time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] < time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] < time].tail(gap).set_index(['datetime', 'code'], drop=False)
                 
             return self.sync_status(QA_DataStruct_Index_day(pd.concat(list(map(lambda x: __lt(x), self.splits())))))
         elif method in ['lte', '<=']:
             def __lte(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] <= time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] <= time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] <= time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] <= time].tail(gap).set_index(['datetime', 'code'], drop=False)
             return self.sync_status(QA_DataStruct_Index_day(pd.concat(list(map(lambda x: __lte(x), self.splits())))))
         elif method in ['e', '==', '=', 'equal']:
             def __eq(__dataS):
@@ -413,17 +413,17 @@ class QA_DataStruct_Index_min(stock_hq_base):
         elif method in ['lt', '<']:
             def __lt(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] < time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] < time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] < time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] < time].tail(gap).set_index(['datetime', 'code'], drop=False)
                 
             return self.sync_status(QA_DataStruct_Index_min(pd.concat(list(map(lambda x: __lt(x), self.splits())))))
         elif method in ['lte', '<=']:
             def __lte(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] <= time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] <= time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] <= time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] <= time].tail(gap).set_index(['datetime', 'code'], drop=False)
             return self.sync_status(QA_DataStruct_Index_min(pd.concat(list(map(lambda x: __lte(x), self.splits())))))
         elif method in ['e', '==', '=', 'equal']:
             def __eq(__dataS):
@@ -591,17 +591,17 @@ class QA_DataStruct_Stock_min(stock_hq_base):
         elif method in ['lt', '<']:
             def __lt(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] < time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] < time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] < time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] < time].tail(gap).set_index(['datetime', 'code'], drop=False)
                 
             return self.sync_status(QA_DataStruct_Stock_min(pd.concat(list(map(lambda x: __lt(x), self.splits())))))
         elif method in ['lte', '<=']:
             def __lte(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] <= time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] <= time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] <= time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] <= time].tail(gap).set_index(['datetime', 'code'], drop=False)
             return self.sync_status(QA_DataStruct_Stock_min(pd.concat(list(map(lambda x: __lte(x), self.splits())))))
         elif method in ['e', '==', '=', 'equal']:
             def __eq(__dataS):
@@ -741,17 +741,17 @@ class QA_DataStruct_Stock_day(stock_hq_base):
         elif method in ['lt', '<']:
             def __lt(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] < time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] < time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] < time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] < time].tail(gap).set_index(['datetime', 'code'], drop=False)
                 
             return self.sync_status(QA_DataStruct_Stock_day(pd.concat(list(map(lambda x: __lt(x), self.splits())))))
         elif method in ['lte', '<=']:
             def __lte(__dataS):
                 if self.type in ['stock_day', 'index_day']:
-                    return __dataS.data[__dataS.data['date'] <= time].head(gap).set_index(['date', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['date'] <= time].tail(gap).set_index(['date', 'code'], drop=False)
                 elif self.type in ['stock_min','index_min']:
-                    return __dataS.data[__dataS.data['datetime'] <= time].head(gap).set_index(['datetime', 'code'], drop=False)
+                    return __dataS.data[__dataS.data['datetime'] <= time].tail(gap).set_index(['datetime', 'code'], drop=False)
             return self.sync_status(QA_DataStruct_Stock_day(pd.concat(list(map(lambda x: __lte(x), self.splits())))))
         elif method in ['e', '==', '=', 'equal']:
             def __eq(__dataS):


### PR DESCRIPTION
修正指数分钟回测QB.market_data没有取到回测日之前的分钟数据导致无法获取交易日前推的分钟线数据。
修正QB.QA_backtest_get_market_data取数据方向相反的问题。