### PR TITLE
add build procedure for WebKit backend #395

### DIFF
--- a/QUANTAXIS_Webkit/backend/package.json
+++ b/QUANTAXIS_Webkit/backend/package.json
@@ -9,7 +9,7 @@
   },
   "bin": "./bin/www",
   "pkg": {
-    "assets": "public/**/*"
+    "assets": ["public/**/*", "views/*"]
   },
   "dependencies": {
     "accepts": "^1.3.3",

--- a/QUANTAXIS_Webkit/backend/package.json
+++ b/QUANTAXIS_Webkit/backend/package.json
@@ -3,8 +3,13 @@
   "version": "0.4.0-alpha",
   "private": true,
   "scripts": {
+    "build": "pkg . -t node8-win-x64 --out-path ./dist",
     "start": "node ./bin/www",
     "debug": "SET DEBUG=nodejsspider:*& npm start"
+  },
+  "bin": "./bin/www",
+  "pkg": {
+    "assets": "public/**/*"
   },
   "dependencies": {
     "accepts": "^1.3.3",
@@ -51,7 +56,9 @@
   },
   "description": "a nodejs version of quantaxis spider",
   "main": "app.js",
-  "devDependencies": {},
+  "devDependencies": {
+    "pkg": "^4.3.0-beta.5"
+  },
   "keywords": [
     "quantaxis",
     "spider"


### PR DESCRIPTION
pkg is used to generate a standalone executable for windows x64.
It could be all platform supported