### PR TITLE
update REALTIME_STRUCT/LINUX CTP CANCELORDER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ QA.concat([QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetc
           QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetch_quotation('000001')).resample('1min'))])
 ```
 4. 修改了QA.QAFetch.QATushare.QA_fetch_get_stock_info(name)的返回结果
-
+5. @逝去的亮光 增加了LINUX环境下的CTP撤单接口
 
 
 ## 1.0.65 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@
 
 1. 修改series_struct 适配单个index的情景
 2. 增加马科维茨有效前沿的研究/ 增加盘中涨停分析的研究 (research/)
+3. QA_DataStruct_Stock_realtime 类发布, 支持自采样
+
+```python
+# 给一个完整版的 (包含 DataStruct合并, DataStruct包装, DataStruct_Realtime采样)
+QA.concat([QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetch_quotation('000636')).resample('1min')),
+          QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetch_quotation('000001')).resample('1min'))])
+```
+4. 修改了QA.QAFetch.QATushare.QA_fetch_get_stock_info(name)的返回结果
+
+
 
 ## 1.0.65 
 

--- a/QUANTAXIS/QAData/QADataStruct.py
+++ b/QUANTAXIS/QAData/QADataStruct.py
@@ -584,149 +584,146 @@ class _realtime_base():
         """
 
         if isinstance(market_data, dict):
-            self.market_data = market_data
+            self.data = market_data
         elif isinstance(market_data, pd.DataFrame):
-            self.market_data = QA_util_to_json_from_pandas(market_data)
+            self.data = QA_util_to_json_from_pandas(market_data)
 
     @property
     def open(self):
-        return self.market_data.get('open', None)
+        return self.data.get('open', None)
 
     @property
     def price(self):
-        return self.market_data.get('price', None)
+        return self.data.get('price', None)
 
     @property
     def datetime(self):
-        return self.market_data.get('datetime', None)
+        return self.data.get('datetime', None)
 
     @property
     def high(self):
-        return self.market_data.get('high', None)
+        return self.data.get('high', None)
 
     @property
     def low(self):
-        return self.market_data.get('low', None)
+        return self.data.get('low', None)
 
     @property
     def code(self):
-        return self.market_data.get('code', None)
+        return self.data.get('code', None)
 
     @property
     def last_close(self):
-        return self.market_data.get('last_close', None)
+        return self.data.get('last_close', None)
 
     @property
     def cur_vol(self):
-        return self.market_data.get('cur_vol', None)
+        return self.data.get('cur_vol', None)
 
     @property
     def bid1(self):
-        return self.market_data.get('bid1', None)
+        return self.data.get('bid1', None)
 
     @property
     def bid_vol1(self):
-        return self.market_data.get('bid_vol1', None)
+        return self.data.get('bid_vol1', None)
 
     @property
     def bid2(self):
-        return self.market_data.get('bid2', None)
+        return self.data.get('bid2', None)
 
     @property
     def bid_vol2(self):
-        return self.market_data.get('bid_vol2', None)
+        return self.data.get('bid_vol2', None)
 
     @property
     def bid3(self):
-        return self.market_data.get('bid3', None)
+        return self.data.get('bid3', None)
 
     @property
     def bid_vol3(self):
-        return self.market_data.get('bid_vol3', None)
+        return self.data.get('bid_vol3', None)
 
     @property
     def bid4(self):
-        return self.market_data.get('bid4', None)
+        return self.data.get('bid4', None)
 
     @property
     def bid_vol4(self):
-        return self.market_data.get('bid_vol4', None)
+        return self.data.get('bid_vol4', None)
 
     @property
     def bid5(self):
-        return self.market_data.get('bid5', None)
+        return self.data.get('bid5', None)
 
     @property
     def bid_vol5(self):
-        return self.market_data.get('bid_vol5', None)
+        return self.data.get('bid_vol5', None)
 
     @property
     def ask1(self):
-        return self.market_data.get('ask1', None)
+        return self.data.get('ask1', None)
 
     @property
     def ask_vol1(self):
-        return self.market_data.get('ask_vol1', None)
+        return self.data.get('ask_vol1', None)
 
     @property
     def ask2(self):
-        return self.market_data.get('ask2', None)
+        return self.data.get('ask2', None)
 
     @property
     def ask_vol2(self):
-        return self.market_data.get('ask_vol2', None)
+        return self.data.get('ask_vol2', None)
 
     @property
     def ask3(self):
-        return self.market_data.get('ask3', None)
+        return self.data.get('ask3', None)
 
     @property
     def ask_vol3(self):
-        return self.market_data.get('ask_vol3', None)
+        return self.data.get('ask_vol3', None)
 
     @property
     def ask4(self):
-        return self.market_data.get('ask4', None)
+        return self.data.get('ask4', None)
 
     @property
     def ask_vol4(self):
-        return self.market_data.get('ask_vol4', None)
+        return self.data.get('ask_vol4', None)
 
     @property
     def ask5(self):
-        return self.market_data.get('ask5', None)
+        return self.data.get('ask5', None)
 
     @property
     def ask_vol5(self):
-        return self.market_data.get('ask_vol5', None)
+        return self.data.get('ask_vol5', None)
 
 
 class QA_DataStruct_Stock_realtime(_realtime_base):
-    def __init__(self, market_data):
-        if isinstance(market_data, dict):
-            self.market_data = market_data
-        elif isinstance(market_data, pd.DataFrame):
-            self.market_data = QA_util_to_json_from_pandas(market_data)
+    def __init__(self, data):
+        self.data=data
 
     def __repr__(self):
-        return '< QA_REALTIME_STRUCT {}{} >'.format(self.code, self.datetime)
+        return '< QA_REALTIME_STRUCT code {} start {} end {} >'.format(self.code.unique(), self.datetime.iloc[1],self.datetime.iloc[-1])
 
     # @property
     # def ask_list(self):
-    #     return self.market_data.ix[:, ['ask1', 'ask_vol1', 'bid1', 'bid_vol1', 'ask2', 'ask_vol2',
+    #     return self.data.ix[:, ['ask1', 'ask_vol1', 'bid1', 'bid_vol1', 'ask2', 'ask_vol2',
     #                                    'bid2', 'bid_vol2', 'ask3', 'ask_vol3', 'bid3', 'bid_vol3', 'ask4',
     #                                    'ask_vol4', 'bid4', 'bid_vol4', 'ask5', 'ask_vol5', 'bid5', 'bid_vol5']]
 
     # @property
     # def bid_list(self):
-    #     return self.market_data.ix[:, ['bid1', 'bid_vol1', 'bid2', 'bid_vol2',  'bid3', 'bid_vol3', 'bid4', 'bid_vol4', 'bid5', 'bid_vol5']]
+    #     return self.data.ix[:, ['bid1', 'bid_vol1', 'bid2', 'bid_vol2',  'bid3', 'bid_vol3', 'bid4', 'bid_vol4', 'bid5', 'bid_vol5']]
 
     @property
     def _data(self):
         """
         return a dataframe-type result
         """
-        return pd.DataFrame(self.market_data)
+        return pd.DataFrame(self.data)
 
     @property
     def ab_board(self):
@@ -753,6 +750,9 @@ class QA_DataStruct_Stock_realtime(_realtime_base):
         """to_protobuf
         """
         pass
+
+    def resample(self, level):
+        return QA_data_tick_resample(self.data, level)
 
 
 class QA_DataStruct_Stock_realtime_series():

--- a/QUANTAXIS/QAData/__init__.py
+++ b/QUANTAXIS/QAData/__init__.py
@@ -33,6 +33,7 @@ from QUANTAXIS.QAData.QADataStruct import (QA_DataStruct_Index_day,
                                            QA_DataStruct_Stock_min,
                                            QA_DataStruct_Future_day,
                                            QA_DataStruct_Future_min,
+                                           QA_DataStruct_Stock_realtime,
                                            QA_DataStruct_Stock_transaction)
 from QUANTAXIS.QAData.QABlockStruct import QA_DataStruct_Stock_block
 from QUANTAXIS.QAData.QAIndicatorStruct import QA_DataStruct_Indicators

--- a/QUANTAXIS/QAData/data_resample.py
+++ b/QUANTAXIS/QAData/data_resample.py
@@ -44,7 +44,7 @@ def QA_data_tick_resample(tick, type_='1min'):
 
     data['volume'] = tick['vol'].resample(
         type_, label='right', closed='left').sum()
-    data['code'] = tick.code.iloc[1].unique()[0]
+    data['code'] = tick.code.iloc[1]
     if 'date' not in tick.columns:
         tick=tick.assign(date=tick.datetime.apply(lambda x: str(x)[0:10]))
 
@@ -55,8 +55,8 @@ def QA_data_tick_resample(tick, type_='1min'):
         _data = _data[time(9, 31):time(11, 30)].append(
             _data[time(13, 1):time(15, 0)])
         resx = resx.append(_data)
-
-    data=resx.reset_index().assign(date=resx['datetime'].apply(lambda x: str(x)[0:10]))
+    resx=resx.reset_index()
+    data=resx.assign(date=resx['datetime'].apply(lambda x: str(x)[0:10]))
 
     return data.fillna(method='ffill').set_index(['datetime', 'code'], drop=False).drop_duplicates()
 

--- a/QUANTAXIS/QAFetch/Fetcher.py
+++ b/QUANTAXIS/QAFetch/Fetcher.py
@@ -43,18 +43,18 @@ from QUANTAXIS.QAUtil.QASql import QA_util_sql_mongo_setting
 
 
 class QA_Fetcher():
-    def __init__(self, ip='127.0.0.1', port=27017, username='',password=''):
+    def __init__(self, uri='mongodb://192.168.4.248:27017/quantaxis', username='',password=''):
         """
         初始化的时候 会初始化
         """
         self.ip = ip
         self.port = port
-        self.database = QA_util_sql_mongo_setting(ip, port).quantaxis
+        self.database = QA_util_sql_mongo_setting(uri).quantaxis
         self.history = {}
         self.best_ip=QATdx.select_best_ip()
 
     def change_ip(self, ip, port):
-        self.database = QA_util_sql_mongo_setting(ip, port).quantaxis
+        self.database = QA_util_sql_mongo_setting(uri).quantaxis
         return self
 
     def get_quotation(self, code=None, start=None, end=None, frequence=None, market=None, source=None, output=None):

--- a/QUANTAXIS/QAFetch/Fetcher.py
+++ b/QUANTAXIS/QAFetch/Fetcher.py
@@ -47,13 +47,12 @@ class QA_Fetcher():
         """
         初始化的时候 会初始化
         """
-        self.ip = ip
-        self.port = port
+
         self.database = QA_util_sql_mongo_setting(uri).quantaxis
         self.history = {}
         self.best_ip=QATdx.select_best_ip()
 
-    def change_ip(self, ip, port):
+    def change_ip(self, uri):
         self.database = QA_util_sql_mongo_setting(uri).quantaxis
         return self
 
@@ -118,8 +117,8 @@ def QA_quotation(code, start, end, frequence, market, source, output):
                 res = QAQueryAdv.QA_fetch_index_day_adv(code, start, end)
 
     elif market is MARKET_TYPE.OPTION_CN:
-        if source is DATABASE_TABLE.MONGO:
-            res = QAQueryAdv.QA_fetch_option_day_adv(code,start,end);
+        if source is DATASOURCE.MONGO:
+            res = QAQueryAdv.QA_fetch_option_day_adv(code,start,end)
     #print(type(res))
     return res
 

--- a/QUANTAXIS/QAFetch/QATushare.py
+++ b/QUANTAXIS/QAFetch/QATushare.py
@@ -67,12 +67,10 @@ def QA_fetch_get_stock_realtime():
 
 def QA_fetch_get_stock_info(name):
     data = QATs.get_stock_basics()
-    data_json = QA_util_to_json_from_pandas(data)
-
-    for i in range(0, len(data_json) - 1, 1):
-        data_json[i]['code'] = data.index[i]
-    return data_json
-
+    try:
+        return data.loc[name]
+    except:
+        return None
 
 def QA_fetch_get_stock_tick(name, date):
     if (len(name) != 6):

--- a/QUANTAXIS/__init__.py
+++ b/QUANTAXIS/__init__.py
@@ -63,7 +63,7 @@ from QUANTAXIS.QAFetch import (QA_fetch_get_stock_day, QA_fetch_get_trade_date, 
                                QA_fetch_get_future_day, QA_fetch_get_future_min, QA_fetch_get_future_list, QA_fetch_get_future_transaction,
                                QA_fetch_get_future_transaction_realtime, QA_fetch_get_future_realtime,
                                QA_fetch_get_hkfund_list, QA_fetch_get_hkfund_day, QA_fetch_get_hkfund_min,
-                               QA_fetch_get_hkindex_list, QA_fetch_get_hkindex_day,QA_fetch_get_hkindex_min,
+                               QA_fetch_get_hkindex_list, QA_fetch_get_hkindex_day, QA_fetch_get_hkindex_min,
                                QA_fetch_get_hkstock_list, QA_fetch_get_hkstock_day, QA_fetch_get_hkstock_min,
                                QA_fetch_get_usstock_list, QA_fetch_get_usstock_day, QA_fetch_get_usstock_min,
                                QA_fetch_get_option_list, QA_fetch_get_option_day, QA_fetch_get_option_min,
@@ -118,7 +118,7 @@ from QUANTAXIS.QAEngine import QA_Thread, QA_Event, QA_Worker, QA_Task, QA_Engin
 from QUANTAXIS.QAData import (QA_data_tick_resample, QA_data_get_hfq, QA_data_get_qfq, QA_data_make_qfq, QA_data_stock_to_fq,
                               QA_data_make_hfq, QA_DataStruct_Stock_day, QA_DataStruct_Stock_min,
                               QA_DataStruct_Future_day, QA_DataStruct_Future_min,
-                              QA_DataStruct_Index_day, QA_DataStruct_Index_min, QA_DataStruct_Indicators,
+                              QA_DataStruct_Index_day, QA_DataStruct_Index_min, QA_DataStruct_Indicators, QA_DataStruct_Stock_realtime,
                               QA_DataStruct_Stock_transaction, QA_DataStruct_Stock_block, QA_DataStruct_Series,
                               from_tushare, QDS_StockMinWarpper, QDS_StockDayWarpper, QDS_IndexDayWarpper, QDS_IndexMinWarpper)
 from QUANTAXIS.QAData.dsmethods import *
@@ -127,7 +127,7 @@ from QUANTAXIS.QAAnalysis import *
 
 # Setting
 
-from QUANTAXIS.QASetting.QALocalize import  qa_path, setting_path, cache_path, download_path, log_path
+from QUANTAXIS.QASetting.QALocalize import qa_path, setting_path, cache_path, download_path, log_path
 
 
 # Util


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~


- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR


## 🛠该PR主要解决的问题🛠:

3. QA_DataStruct_Stock_realtime 类发布, 支持自采样

```python
# 给一个完整版的 (包含 DataStruct合并, DataStruct包装, DataStruct_Realtime采样)
QA.concat([QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetch_quotation('000636')).resample('1min')),
          QA.QA_DataStruct_Stock_min(QA.QA_DataStruct_Stock_realtime(QA.QA_fetch_quotation('000001')).resample('1min'))])
```
4. 修改了QA.QAFetch.QATushare.QA_fetch_get_stock_info(name)的返回结果
5. @逝去的亮光 增加了LINUX环境下的CTP撤单接口


🤹‍作者信息:
⏰时间: 
