### PR TITLE
Update requirement on pytdx

### DIFF
--- a/install_afterrequirements.txt
+++ b/install_afterrequirements.txt
@@ -1,2 +1,2 @@
 tushare
-pytdx>=1.68
+pytdx>=1.67


### PR DESCRIPTION
The latest version of pytdx is 1.67 - see https://pypi.org/project/pytdx/#history.