### PR TITLE
QAIndicator部分指标修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
     - [1.0.25](#1025)
 
 <!-- /TOC -->
+## 1.2.9
+1. QAIndicator部分指标修正,base.py增加IFAND函数,indicator.py部分指标修正
 
 ## 1.2.8
 

--- a/QUANTAXIS/QAIndicator/base.py
+++ b/QUANTAXIS/QAIndicator/base.py
@@ -142,6 +142,15 @@ def IF(COND, V1, V2):
     return pd.Series(var, index=V1.index)
 
 
+def IFAND(COND1, COND2, V1, V2):
+    var = np.where(np.logical_and(COND1,COND2), V1, V2)
+    return pd.Series(var, index=V1.index)
+    
+def IFOR(COND1, COND2, V1, V2):
+    var = np.where(np.logical_or(COND1,COND2), V1, V2)
+    return pd.Series(var, index=V1.index)
+
+
 def REF(Series, N):
     var = Series.diff(N)
     var = Series - var

--- a/QUANTAXIS/QAIndicator/indicators.py
+++ b/QUANTAXIS/QAIndicator/indicators.py
@@ -105,8 +105,8 @@ def QA_indicator_DMI(DataFrame, M1=14, M2=6):
                  ABS(LOW-REF(CLOSE, 1))), M1)
     HD = HIGH-REF(HIGH, 1)
     LD = REF(LOW, 1)-LOW
-    DMP = SUM(IF(HD > 0 and HD > LD, HD, 0), M1)
-    DMM = SUM(IF(LD > 0 and LD > HD, LD, 0), M1)
+    DMP = SUM(IFAND(HD>0,HD>LD,HD,0), M1)
+    DMM = SUM(IFAND(LD>0,LD>HD,LD,0), M1)
     DI1 = DMP*100/TR
     DI2 = DMM*100/TR
     ADX = MA(ABS(DI2-DI1)/(DI1+DI2)*100, M2)
@@ -295,13 +295,12 @@ def QA_indicator_ADTM(DataFrame, N=23, M=8):
     HIGH = DataFrame.high
     LOW = DataFrame.low
     OPEN = DataFrame.open
-    DTM = IF(OPEN <= REF(OPEN, 1), 0, MAX(
-        (HIGH - OPEN), (OPEN - REF(OPEN, 1))))
-    DBM = IF(OPEN >= REF(OPEN, 1), 0, MAX((OPEN - LOW), (OPEN - REF(OPEN, 1))))
+    DTM = IF(OPEN > REF(OPEN, 1), MAX((HIGH - OPEN), (OPEN - REF(OPEN, 1))), 0)
+    DBM = IF(OPEN < REF(OPEN, 1), MAX((OPEN - LOW), (OPEN - REF(OPEN, 1))), 0)
     STM = SUM(DTM, N)
     SBM = SUM(DBM, N)
     ADTM1 = IF(STM > SBM, (STM - SBM) / STM,
-               IF(STM == SBM, 0, (STM - SBM) / SBM))
+               IF(STM != SBM, (STM - SBM) / SBM, 0))
     MAADTM = MA(ADTM1, M)
     DICT = {'ADTM': ADTM1, 'MAADTM': MAADTM}
 
@@ -409,8 +408,8 @@ def QA_indicator_ASI(DataFrame, M1=26, M2=10):
     CC = ABS(HIGH - REF(LOW, 1))
     DD = ABS(LC - REF(OPEN, 1))
 
-    R = IF(AA > BB and AA > CC, AA+BB/2+DD/4,
-           IF(BB > CC and BB > AA, BB+AA/2+DD/4, CC+DD/4))
+    R = IFAND(AA > BB, AA > CC, AA+BB/2+DD/4,
+           IFAND(BB > CC, BB > AA, BB+AA/2+DD/4, CC+DD/4))
     X = (CLOSE - LC + (CLOSE - OPEN) / 2 + LC - REF(OPEN, 1))
     SI = 16*X/R*MAX(AA, BB)
     ASI = SUM(SI, M1)
@@ -431,8 +430,8 @@ def QA_indicator_OBV(DataFrame):
     """能量潮"""
     VOL = DataFrame.volume
     CLOSE = DataFrame.close
-    pd.DataFrame({
-        'OBV': SUM(IF(CLOSE > REF(CLOSE, 1), VOL, IF(CLOSE < REF(CLOSE, 1), -VOL, 0)), 0)/10000
+    return pd.DataFrame({
+        'OBV': np.cumsum(IF(CLOSE > REF(CLOSE, 1), VOL, IF(CLOSE < REF(CLOSE, 1), -VOL, 0)))/10000
     })
 
 
@@ -570,10 +569,10 @@ def QA_indicator_DDI(DataFrame, N=13, N1=26, M=1, M1=5):
 
     H = DataFrame['high']
     L = DataFrame['low']
-    DMZ = IF((H + L) <= (REF(H, 1) + REF(L, 1)), 0,
-             MAX(ABS(H - REF(H, 1)), ABS(L - REF(L, 1))))
-    DMF = IF((H + L) >= (REF(H, 1) + REF(L, 1)), 0,
-             MAX(ABS(H - REF(H, 1)), ABS(L - REF(L, 1))))
+    DMZ = IF((H + L) > (REF(H, 1) + REF(L, 1)), 
+             MAX(ABS(H - REF(H, 1)), ABS(L - REF(L, 1))), 0)
+    DMF = IF((H + L) < (REF(H, 1) + REF(L, 1)),
+             MAX(ABS(H - REF(H, 1)), ABS(L - REF(L, 1))), 0)
     DIZ = SUM(DMZ, N) / (SUM(DMZ, N) + SUM(DMF, N))
     DIF = SUM(DMF, N) / (SUM(DMF, N) + SUM(DMZ, N))
     ddi = DIZ - DIF


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
修复部分指标逻辑与导致ValueError: The truth value of a DataFrame is ambiguous.的错误，
base.py增加IFAND函数，使用np.logical_and()。
修改indicator.py 中 QA_indicator_DMI，QA_indicator_ASI；
QA_indicator_DDI，QA_indicator_ADTM中IF的index返回错误，0位置互换。
修正QA_indicator_OBV，能量潮的积累是所取得部分日期的积累，曲线形态与TDX一致。


作者信息: qq550806968小编
时间: 20190126
