### PR TITLE
config出错不能读取，可能的处理方式。

### DIFF
--- a/QUANTAXIS/QAFetch/QATdx.py
+++ b/QUANTAXIS/QAFetch/QATdx.py
@@ -112,12 +112,18 @@ def select_best_ip():
 
     ipexclude = qasetting.get_config(
         section='IPLIST', option='exclude', default_value=alist)
-    exclude_from_stock_ip_list(json.loads(ipexclude))
+    
+    if ipexclude != None:
+        exclude_from_stock_ip_list(json.loads(ipexclude))
 
     ipdefault = qasetting.get_config(
         section='IPLIST', option='default', default_value=default_ip)
-
-    ipdefault = eval(ipdefault) if isinstance(ipdefault, str) else ipdefault
+        
+    if ipdefault != None:
+        ipdefault = eval(ipdefault) if isinstance(ipdefault, str) else ipdefault
+    else:
+        ipdefault = default_ip 
+        
     assert isinstance(ipdefault, dict)
 
     if ipdefault['stock']['ip'] == None:

--- a/QUANTAXIS/QAUtil/QALogs.py
+++ b/QUANTAXIS/QAUtil/QALogs.py
@@ -45,7 +45,15 @@ CONFIGFILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'config.ini')
 def get_config():
     config = configparser.ConfigParser()
     if os.path.exists(CONFIGFILE_PATH):
-        config.read(CONFIGFILE_PATH)
+        try:
+            config.read(CONFIGFILE_PATH)
+        except:
+            config.clear()  #config.read出错失败，清空CONFIG，重新设置LOG。
+            config.add_section('LOG')
+            config.set('LOG', 'path', log_path)
+            with open(CONFIGFILE_PATH, 'w') as f:
+                config.write(f)
+            return log_path   
         try:
             return config.get('LOG', 'path')
         except configparser.NoSectionError:

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -71,7 +71,13 @@ class QA_Setting():
 
         config = configparser.ConfigParser()
         if os.path.exists(CONFIGFILE_PATH):
-            config.read(CONFIGFILE_PATH)
+            try:
+                config.read(CONFIGFILE_PATH)
+            except:
+                config.clear()  #config.read出错失败，清空CONFIG
+                with open(CONFIGFILE_PATH, 'w') as f:
+                    config.write(f)
+                return None  #无法读取返回None。
             return self.get_or_set_section(
                 config,
                 section,
@@ -109,7 +115,12 @@ class QA_Setting():
 
         config = configparser.ConfigParser()
         if os.path.exists(CONFIGFILE_PATH):
-            config.read(CONFIGFILE_PATH)
+            try:
+                config.read(CONFIGFILE_PATH)
+            except:
+                config.clear()  #config.read出错失败，清空CONFIG，重新设置。
+                with open(CONFIGFILE_PATH, 'w') as f:
+                    config.write(f) 
             return self.get_or_set_section(
                 config,
                 section,


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
多进程同时启动导致config出错不能读取。config.read(CONFIGFILE_PATH)出错失败后处理：
1. QALogs，get_config()清空重写并直接返回log_path
2. QASetting ，get_config()清空并返回None，致使QATdx修改None的情况

作者信息:carltiger  qq550806968小编
时间: 20190205
