### PR TITLE
update: 减少对于account的智障获取

### DIFF
--- a/EXAMPLE/2_类的测试与讲解/QAACCOUNT 保证金冻结释放测试.ipynb
+++ b/EXAMPLE/2_类的测试与讲解/QAACCOUNT 保证金冻结释放测试.ipynb
@@ -136,7 +136,7 @@
     }
    ],
    "source": [
-    "user.save()"
+    "acc.save()"
    ]
   },
   {

--- a/EXAMPLE/4_回测实盘交易/QA_MARKETENGINE.py
+++ b/EXAMPLE/4_回测实盘交易/QA_MARKETENGINE.py
@@ -272,6 +272,6 @@ market.session[a_1.account_cookie].history
 
 
 #%%
-user.save()
+ac.save()
 
 

--- a/EXAMPLE/4_回测实盘交易/回测/期货回测/future_min_backtest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/期货回测/future_min_backtest.py
@@ -122,5 +122,5 @@ Risk.plot_assets_curve()
 Risk.profit_construct
 
 
-user.save()
+Account.save()
 Risk.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/基于QAMARKET的回测/backtest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/基于QAMARKET的回测/backtest.py
@@ -56,7 +56,7 @@ class Backtest(QA_Backtest):
         fig.show()
         fig=risk.plot_signal()
         fig.show()
-        self.user.save()
+        self.account.save()
         risk.save()
 
 

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/多季度选股择时回测.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/多季度选股择时回测.py
@@ -103,7 +103,7 @@ simple_backtest(AC, QA.QA_fetch_stock_block_adv(
 
 
 print(AC.message)
-User.save()
+AC.save()
 risk = QA.QA_Risk(AC)
 print(risk.message)
 risk.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/MACD_JCSC.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/MACD_JCSC.py
@@ -93,7 +93,7 @@ print(Account.daily_hold)
 # create Risk analysis
 Risk = QA.QA_Risk(Account)
 
-user.save()
+Account.save()
 Risk.save()
 
 

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/simple_minbacktest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/simple_minbacktest.py
@@ -79,5 +79,5 @@ r.plot_assets_curve().show()
 
 print(r.profit_construct)
 
-User.save()
+Account.save()
 r.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/simplebacktest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/简易回测/simplebacktest.py
@@ -106,7 +106,7 @@ def simple_backtest(AC, code, start, end):
 simple_backtest(AC, QA.QA_fetch_stock_block_adv(
 ).code[0:10], '2017-01-01', '2018-01-31')
 print(AC.message)
-User.save()
+AC.save()
 risk = QA.QA_Risk(AC)
 print(risk.message)
 risk.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/MACD_JCSC.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/MACD_JCSC.py
@@ -93,7 +93,7 @@ print(Account.daily_hold)
 # create Risk analysis
 Risk = QA.QA_Risk(Account)
 
-user.save()
+Account.save()
 Risk.save()
 
 

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/simple_minbacktest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/simple_minbacktest.py
@@ -69,5 +69,5 @@ r.plot_assets_curve().show()
 
 print(r.profit_construct)
 
-User.save()
+Account.save()
 r.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/simplebacktest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票回测/超级简化版回测/simplebacktest.py
@@ -90,7 +90,7 @@ def simple_backtest(AC, code, start, end):
 simple_backtest(AC, QA.QA_fetch_stock_block_adv(
 ).code[0:10], '2017-01-01', '2018-01-31')
 print(AC.message)
-User.save()
+AC.save()
 risk = QA.QA_Risk(AC)
 print(risk.message)
 risk.save()

--- a/EXAMPLE/4_回测实盘交易/回测/股票日内交易回测/T0backtest.py
+++ b/EXAMPLE/4_回测实盘交易/回测/股票日内交易回测/T0backtest.py
@@ -98,7 +98,7 @@ class Backtest(QA_Backtest):
                        benchmark_type=MARKET_TYPE.INDEX_CN)
 
         print(risk().T)
-        self.user.save()
+        self.account.save()
         risk.save()
         risk.plot_assets_curve()
         print(risk.profit_construct)

--- a/EXAMPLE/test_backtest/T0backtest.py
+++ b/EXAMPLE/test_backtest/T0backtest.py
@@ -98,7 +98,7 @@ class Backtest(QA_Backtest):
                        benchmark_type=MARKET_TYPE.INDEX_CN)
 
         print(risk().T)
-        self.user.save()
+        self.account.save()
         risk.save()
         risk.plot_assets_curve()
         print(risk.profit_construct)

--- a/EXAMPLE/test_backtest/TEST_ ORDER(stock+T0+Future).ipynb
+++ b/EXAMPLE/test_backtest/TEST_ ORDER(stock+T0+Future).ipynb
@@ -2178,7 +2178,7 @@
     }
    ],
    "source": [
-    "user.save()"
+    "AccountFuture.save()"
    ]
   },
   {

--- a/QUANTAXIS/QAARP/QAPortfolio.py
+++ b/QUANTAXIS/QAARP/QAPortfolio.py
@@ -136,7 +136,6 @@ class QA_Portfolio(QA_Account):
 
         try:
             return self.get_account_by_cookie(account_cookie)
-            )
         except:
             return None
 

--- a/QUANTAXIS/QAARP/QAPortfolio.py
+++ b/QUANTAXIS/QAARP/QAPortfolio.py
@@ -535,9 +535,9 @@ class QA_Portfolio(QA_Account):
             upsert=True
         )
 
-        for account in self.accounts.values():
-            print('account {} save'.format(account.account_cookie))
-            account.save()
+        # for account in self.accounts.values():
+        #     print('account {} save'.format(account.account_cookie))
+        #     account.save()
 
 
 class QA_PortfolioView():

--- a/QUANTAXIS/QAARP/QAPortfolio.py
+++ b/QUANTAXIS/QAARP/QAPortfolio.py
@@ -135,7 +135,8 @@ class QA_Portfolio(QA_Account):
         """
 
         try:
-            return self.accounts[account_cookie]
+            return self.get_account_by_cookie(account_cookie)
+            )
         except:
             return None
 
@@ -171,7 +172,6 @@ class QA_Portfolio(QA_Account):
                 ]
             )
         )
-
 
     @property
     def init_hold_table(self):
@@ -271,7 +271,7 @@ class QA_Portfolio(QA_Account):
         else:
             if self.cash_available >= init_cash:
                 if account_cookie not in self.account_list:
-                    
+
                     acc = QA_Account(
                         portfolio_cookie=self.portfolio_cookie,
                         user_cookie=self.user_cookie,
@@ -286,7 +286,7 @@ class QA_Portfolio(QA_Account):
                     self.cash.append(self.cash_available - init_cash)
                     return acc
                 else:
-                    return self.accounts[account_cookie]
+                    return self.get_account_by_cookie(account_cookie)
 
     def get_account_by_cookie(self, cookie):
         '''
@@ -296,7 +296,12 @@ class QA_Portfolio(QA_Account):
                  None not in list
         '''
         try:
-            return self.accounts[cookie]
+            return QA_Account(
+                account_cookie=account_cookie,
+                user_cookie=self.user_cookie,
+                portfolio_cookie=self.portfolio_cookie,
+                auto_reload=True
+            )
         except:
             QA_util_log_info('Can not find this account')
             return None
@@ -309,7 +314,7 @@ class QA_Portfolio(QA_Account):
                  None not in list
         '''
         try:
-            return self.accounts[account.account_cookie]
+            return self.get_account_by_cookie(account.account_cookie)
         except:
             QA_util_log_info(
                 'Can not find this account with cookies %s' %
@@ -366,7 +371,7 @@ class QA_Portfolio(QA_Account):
             [type] -- [description]
         """
 
-        return self.accounts[account_cookie].send_order(
+        return self.get_account_by_cookie(account_cookie).send_order(
             code=code,
             amount=amount,
             time=time,
@@ -384,10 +389,6 @@ class QA_Portfolio(QA_Account):
     def table(self):
         return pd.concat([acc.table for acc in self.accounts.values()], axis=1)
 
-    def evaluate(self, account):
-        account = self.accounts[account]
-
-        risk = QA_Risk(account)
 
     @property
     def portfolioView(self):
@@ -403,66 +404,66 @@ class QA_Portfolio(QA_Account):
             [account.cash_available for account in self.accounts.values()]
         )
 
-    def pull(self, account_cookie=None, collection=DATABASE.account):
-        'pull from the databases'
-        if account_cookie is None:
-            for item in self.account_list:
-                try:
-                    message = collection.find_one({'account_cookie': item})
-                    QA_util_log_info('{} sync successfully'.format(item))
-                except Exception as e:
-                    QA_util_log_info(
-                        '{} sync wrong \\\n wrong info {}'.format(item,
-                                                                  e)
-                    )
-                self.accounts[item].from_message(message)
+    # def pull(self, account_cookie=None, collection=DATABASE.account):
+    #     'pull from the databases'
+    #     if account_cookie is None:
+    #         for item in self.account_list:
+    #             try:
+    #                 message = collection.find_one({'account_cookie': item})
+    #                 QA_util_log_info('{} sync successfully'.format(item))
+    #             except Exception as e:
+    #                 QA_util_log_info(
+    #                     '{} sync wrong \\\n wrong info {}'.format(item,
+    #                                                               e)
+    #                 )
+    #             self.accounts[item].from_message(message)
 
-        else:
-            try:
-                message = collection.find_one(
-                    {'account_cookie': account_cookie}
-                )
-                QA_util_log_info('{} sync successfully'.format(item))
-            except Exception as e:
-                QA_util_log_info(
-                    '{} sync wrong \\\n wrong info {}'.format(
-                        account_cookie,
-                        e
-                    )
-                )
-            self.accounts[account_cookie].from_message(message)
+    #     else:
+    #         try:
+    #             message = collection.find_one(
+    #                 {'account_cookie': account_cookie}
+    #             )
+    #             QA_util_log_info('{} sync successfully'.format(item))
+    #         except Exception as e:
+    #             QA_util_log_info(
+    #                 '{} sync wrong \\\n wrong info {}'.format(
+    #                     account_cookie,
+    #                     e
+    #                 )
+    #             )
+    #         self.accounts[account_cookie].from_message(message)
 
-    def push(self, account_cookie=None, collection=DATABASE.account):
-        'push to databases'
-        message = self.accounts[account_cookie].message
-        if account_cookie is None:
-            for item in self.account_list:
-                try:
-                    message = collection.find_one_and_update(
-                        {'account_cookie': item}
-                    )
-                    QA_util_log_info('{} sync successfully'.format(item))
-                except Exception as e:
-                    QA_util_log_info(
-                        '{} sync wrong \\\n wrong info {}'.format(item,
-                                                                  e)
-                    )
-                self.accounts[item].from_message(message)
+    # def push(self, account_cookie=None, collection=DATABASE.account):
+    #     'push to databases'
+    #     message = self.accounts[account_cookie].message
+    #     if account_cookie is None:
+    #         for item in self.account_list:
+    #             try:
+    #                 message = collection.find_one_and_update(
+    #                     {'account_cookie': item}
+    #                 )
+    #                 QA_util_log_info('{} sync successfully'.format(item))
+    #             except Exception as e:
+    #                 QA_util_log_info(
+    #                     '{} sync wrong \\\n wrong info {}'.format(item,
+    #                                                               e)
+    #                 )
+    #             self.accounts[item].from_message(message)
 
-        else:
-            try:
-                message = collection.find_one(
-                    {'account_cookie': account_cookie}
-                )
-                QA_util_log_info('{} sync successfully'.format(item))
-            except Exception as e:
-                QA_util_log_info(
-                    '{} sync wrong \\\n wrong info {}'.format(
-                        account_cookie,
-                        e
-                    )
-                )
-            self.accounts[account_cookie].from_message(message)
+    #     else:
+    #         try:
+    #             message = collection.find_one(
+    #                 {'account_cookie': account_cookie}
+    #             )
+    #             QA_util_log_info('{} sync successfully'.format(item))
+    #         except Exception as e:
+    #             QA_util_log_info(
+    #                 '{} sync wrong \\\n wrong info {}'.format(
+    #                     account_cookie,
+    #                     e
+    #                 )
+    #             )
+    #         self.accounts[account_cookie].from_message(message)
 
     @property
     def history_split(self):
@@ -512,7 +513,7 @@ class QA_Portfolio(QA_Account):
                 {'user_cookie': self.user_cookie, 'portfolio_cookie': self.portfolio_cookie})]
             #self.history = (message['history'], message['history_header'])
             #account_list = message['account_list']
-            
+
     @property
     def code(self):
         """code of portfolio ever hold

--- a/QUANTAXIS/QAApplication/QABacktest.py
+++ b/QUANTAXIS/QAApplication/QABacktest.py
@@ -213,7 +213,7 @@ class QA_Backtest():
                 print(ac.hold)
 
                 print(ac.history_table)
-        self.user.save()
+                ac.save()
         self.stop()
 
     def stop(self):

--- a/releaseNote.md
+++ b/releaseNote.md
@@ -26,12 +26,12 @@ portfolio =  user.new_portfolio('qatestportfolio')
 account = portfolio.new_account(account_cookie='test_a', init_cash= 200000, ....)
 
 ```
-2. 在你退出这个程序的时候 如果你想保存这个过程, 使用 ```QA_User.save()```
+2. 在你退出这个程序的时候 如果你想保存这个过程, 使用 ```account.save()```
 
 ```python
 ###
 
-user.save()
+account.save()
 ```
 
 3. 从组合中删除一个 QA_Account的过程:


### PR DESCRIPTION
#在1.3.0中, user.save会带动底下的portfolio.save ==> 进而导致user下的所有account都被save一次, load也一样, 在只有2-3个account时不会导致什么问题 但是当有5000个以上的account以后 此过程变得极其之慢且没有必要, 因此对此进行一定的优化


portfolio ==> 用到及创建

account ==> 操作结束后 account.save() [以前是user.save]

account可以被多次save 是更新操作

取消加载portfolio的时候的默认load操作 变成惰性加载, 用到再去取
参见(portfolio.account_list 以及 accounts的操作改动)
