### PR TITLE
增加回测结果任意区间查看功能

### DIFF
--- a/QUANTAXIS/QAARP/QARisk.py
+++ b/QUANTAXIS/QAARP/QARisk.py
@@ -206,12 +206,10 @@ class QA_Risk():
         return pd.DataFrame([self.message])
 
     @property
-    @lru_cache()
     def total_timeindex(self):
         return self.account.trade_range
 
     @property
-    @lru_cache()
     def market_value(self):
         """每日每个股票持仓市值表
 
@@ -235,7 +233,6 @@ class QA_Risk():
             return None
 
     @property
-    @lru_cache()
     def daily_market_value(self):
         """每日持仓总市值表
 
@@ -316,7 +313,7 @@ class QA_Risk():
             [type] -- [description]
         """
 
-        return float(round(self.assets.iloc[-1] - self.init_cash, 2))
+        return float(round(self.assets.iloc[-1] - self.assets.iloc[0], 2))
 
     @property
     def profit(self):
@@ -381,7 +378,7 @@ class QA_Risk():
             'beta': self.beta,
             'alpha': self.alpha,
             'sharpe': self.sharpe,
-            'init_cash': "%0.2f" % (float(self.init_cash)),
+            'init_cash': "%0.2f" % (float(self.assets[0])),
             'last_assets': "%0.2f" % (float(self.assets.iloc[-1])),
             'total_tax': self.total_tax,
             'total_commission': self.total_commission,
@@ -413,8 +410,8 @@ class QA_Risk():
         基准组合的账户资产队列
         """
         return (
-            self.benchmark_data.close / float(self.benchmark_data.open.iloc[0])
-            * float(self.init_cash)
+            self.benchmark_data.close / float(self.benchmark_data.close.iloc[0])
+            * float(self.assets[0])
         )
 
     @property
@@ -559,7 +556,7 @@ class QA_Risk():
         计算账户收益
         期末资产/期初资产 -1
         """
-        return (float(assets.iloc[-1]) / float(self.init_cash)) - 1
+        return (float(assets.iloc[-1]) / float(assets.iloc[0])) - 1
 
     def calc_sharpe(self, annualized_returns, volatility_year, r=0.05):
         """
@@ -736,7 +733,7 @@ class QA_Risk():
     @property
     def month_assets_profit(self):
 
-        res = pd.concat([pd.Series(self.init_cash), self.month_assets]).diff().dropna()
+        res = pd.concat([pd.Series(self.assets.iloc[0]), self.month_assets]).diff().dropna()
         res.index = res.index.map(str)
         return res
     @property
@@ -978,7 +975,6 @@ class QA_Performance():
         pass
 
     @property
-    @lru_cache()
     def pnl_lifo(self):
         """
         使用后进先出法配对成交记录
@@ -990,7 +986,7 @@ class QA_Performance():
             )
         )
         pair_table = []
-        for _, data in self.target.history_table.iterrows():
+        for _, data in self.perf.target.history_table_min.iterrows():
             while True:
                 if X[data.code].qsize() == 0:
                     X[data.code].put((data.datetime, data.amount, data.price))
@@ -1022,8 +1018,9 @@ class QA_Performance():
                                         l[0],
                                         data.datetime,
                                         abs(data.amount),
-                                        l[2],
-                                        data.price
+                                        data.price,                                        
+                                        l[2]
+
                                         
                                     ]
                                 )
@@ -1111,7 +1108,6 @@ class QA_Performance():
         return pnl
 
     @property
-    @lru_cache()
     def pnl_fifo(self):
         X = dict(
             zip(
@@ -1120,7 +1116,7 @@ class QA_Performance():
             )
         )
         pair_table = []
-        for _, data in self.target.history_table.iterrows():
+        for _, data in self.target.history_table_min.iterrows():
             while True:
                 if len(X[data.code]) == 0:
                     X[data.code].append(
@@ -1132,7 +1128,6 @@ class QA_Performance():
                 else:
                     l = X[data.code].popleft()
                     if (l[1] * data.amount) < 0:
-                        # 空单信号
                         # 原有多仓/ 平仓 或者原有空仓/平仓
 
                         if abs(l[1]) > abs(data.amount):
@@ -1208,14 +1203,14 @@ class QA_Performance():
                                         l[0],
                                         data.datetime,
                                         abs(data.amount),
-                                        l[2],
-                                        data.price
+                                        data.price,                                      
+                                        l[2]
+
                                     ]
                                 )
                                 break
 
                     else:
-                        #多单
                         X[data.code].appendleft(l)
                         X[data.code].appendleft(
                             (data.datetime,
@@ -1394,7 +1389,10 @@ class QA_Performance():
             elif item < 0:
                 w.append(w1)
                 w1 = 0
-        return max(w)
+        if len(w)==0:
+            return 0
+        else:
+            return max(w)            
 
     @property
     def continue_loss_amount(self):
@@ -1406,7 +1404,10 @@ class QA_Performance():
             elif item < 0:
                 l.append(l1)
                 l1 = 0
-        return max(l)
+        if len(l)==0:
+            return 0
+        else:
+            return max(l)               
 
     @property
     def average_holdgap(self):
@@ -1430,5 +1431,5 @@ class QA_Performance():
 
     @property
     def total_taxfee(self):
-        return self.target.history_table.commission.sum(
-        ) + self.target.history_table.tax.sum()
+        return self.target.history_table_min.commission.sum(
+        ) + self.target.history_table_min.tax.sum()


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
1.增加回测结果任意区间查看功能，只需指定account..start_和account.end_即可。
2.修复最大连胜和连败次数为0时 出错的BUG。
![image](https://user-images.githubusercontent.com/40067351/55327045-cc9d7700-54bb-11e9-9a6e-dfceddccc672.png)
![image](https://user-images.githubusercontent.com/40067351/55327069-d6bf7580-54bb-11e9-8c80-6cc347c00c49.png)
![image](https://user-images.githubusercontent.com/40067351/55327102-eccd3600-54bb-11e9-8730-663163ed17ca.png)

作者信息:
时间: 
