### PR TITLE
试图解决的 多进程读写出错问题

### DIFF
--- a/QUANTAXIS/QAFetch/QATdx.py
+++ b/QUANTAXIS/QAFetch/QATdx.py
@@ -116,7 +116,7 @@ def select_best_ip():
     ipexclude = qasetting.get_config(
         section='IPLIST', option='exclude', default_value=alist)
 
-    exclude_from_stock_ip_list(json.loads(ipexclude.replace("'", "\"")))
+    exclude_from_stock_ip_list(ipexclude)
 
     ipdefault = qasetting.get_config(
         section='IPLIST', option='default', default_value=default_ip)

--- a/QUANTAXIS/QAMarket/QAShipaneBroker.py
+++ b/QUANTAXIS/QAMarket/QAShipaneBroker.py
@@ -31,9 +31,8 @@ from QUANTAXIS.QAUtil.QAParameter import (
     ORDER_MODEL,
     ORDER_STATUS
 )
-from QUANTAXIS.QAUtil.QASetting import setting_path
+from QUANTAXIS.QAUtil.QASetting import setting_path, QA_Setting
 
-CONFIGFILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'config.ini')
 DEFAULT_SHIPANE_URL = 'http://127.0.0.1:8888'
 DEFAULT_SHIPANE_KEY = ''
 
@@ -47,40 +46,10 @@ class SPE_CONFIG():
 
 def get_config_SPE():
     config = configparser.ConfigParser()
-
-    if os.path.exists(CONFIGFILE_PATH):
-        config.read(CONFIGFILE_PATH)
-        try:
-
-            return SPE_CONFIG(
-                config.get('SPE',
-                           'uri'),
-                config.get('SPE',
-                           'key')
-            )
-
-        except configparser.NoSectionError:
-            config.add_section('SPE')
-            config.set('SPE', 'uri', DEFAULT_SHIPANE_URL)
-            config.set('SPE', 'key', DEFAULT_SHIPANE_KEY)
-            return SPE_CONFIG()
-        except configparser.NoOptionError:
-            config.set('SPE', 'uri', DEFAULT_SHIPANE_URL)
-            config.set('SPE', 'key', DEFAULT_SHIPANE_KEY)
-            return SPE_CONFIG()
-        finally:
-
-            with open(CONFIGFILE_PATH, 'w') as f:
-                config.write(f)
-
-    else:
-        f = open(CONFIGFILE_PATH, 'w')
-        config.add_section('SPE')
-        config.set('SPE', 'uri', DEFAULT_SHIPANE_URL)
-        config.set('SPE', 'key', DEFAULT_SHIPANE_KEY)
-        config.write(f)
-        f.close()
-        return DEFAULT_SHIPANE_URL
+    return SPE_CONFIG(
+        QA_Setting().get_config('SPE', 'uri', DEFAULT_SHIPANE_URL),
+        QA_Setting().get_config('SPE', 'key', DEFAULT_SHIPANE_KEY)
+    )
 
 
 class QA_SPEBroker(QA_Broker):
@@ -388,13 +357,13 @@ class QA_SPEBroker(QA_Broker):
                                          self.dealstatus_headers].set_index(
                                              ['account_cookie',
                                               'realorder_id']
-                                         ).sort_index()
+                    ).sort_index()
                 else:
                     return order_all.loc[:,
                                          self.orderstatus_headers].set_index(
                                              ['account_cookie',
                                               'realorder_id']
-                                         ).sort_index()
+                    ).sort_index()
             else:
                 print('response is None')
                 return False

--- a/QUANTAXIS/QAUtil/QALogs.py
+++ b/QUANTAXIS/QAUtil/QALogs.py
@@ -36,54 +36,22 @@ import datetime
 import os
 import sys
 from zenlog import logging
-from multiprocessing import Lock
 from QUANTAXIS.QASetting.QALocalize import log_path, setting_path
-
-CONFIGFILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'config.ini')
-
-
-def get_config():
-    config = configparser.ConfigParser()
-    L= Lock()
-    L.acquire()
-    if os.path.exists(CONFIGFILE_PATH):
-        config.read(CONFIGFILE_PATH)
-        try:
-            return config.get('LOG', 'path')
-        except configparser.NoSectionError:
-            config.add_section('LOG')
-            config.set('LOG', 'path', log_path)
-            return log_path
-        except configparser.NoOptionError:
-            config.set('LOG', 'path', log_path)
-            return log_path
-        finally:
-
-            with open(CONFIGFILE_PATH, 'w') as f:
-                config.write(f)
-
-    else:
-        f = open(CONFIGFILE_PATH, 'w')
-        config.add_section('LOG')
-        config.set('LOG', 'path', log_path)
-        config.write(f)
-        f.close()
-        return log_path
-    L.release()
+from QUANTAXIS.QAUtil.QASetting import QA_Setting
 
 
 """2019-01-03  升级到warning级别 不然大量别的代码的log会批量输出出来
 """
 try:
     _name = '{}{}quantaxis_{}-{}-.log'.format(
-        get_config(),
+        QA_Setting().get_config('LOG','path', log_path),
         os.sep,
         os.path.basename(sys.argv[0]).split('.py')[0],
         str(datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
     )
 except:
     _name = '{}{}quantaxis-{}-.log'.format(
-        get_config(),
+        QA_Setting().get_config('LOG','path', log_path),
         os.sep,
         str(datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
     )

--- a/QUANTAXIS/QAUtil/QALogs.py
+++ b/QUANTAXIS/QAUtil/QALogs.py
@@ -36,7 +36,7 @@ import datetime
 import os
 import sys
 from zenlog import logging
-
+from multiprocessing import Lock
 from QUANTAXIS.QASetting.QALocalize import log_path, setting_path
 
 CONFIGFILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'config.ini')
@@ -44,6 +44,8 @@ CONFIGFILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'config.ini')
 
 def get_config():
     config = configparser.ConfigParser()
+    L= Lock()
+    L.acquire()
     if os.path.exists(CONFIGFILE_PATH):
         config.read(CONFIGFILE_PATH)
         try:
@@ -67,6 +69,7 @@ def get_config():
         config.write(f)
         f.close()
         return log_path
+    L.release()
 
 
 """2019-01-03  升级到warning级别 不然大量别的代码的log会批量输出出来

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -43,16 +43,37 @@ INFO_IP_FILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'info_ip.json')
 STOCK_IP_FILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'stock_ip.json')
 FUTURE_IP_FILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'future_ip.json')
 
+
 class QA_Setting():
 
     def __init__(self, uri=None):
         self.lock = Lock()
-        self.mongo_uri = uri or self.get_config() or self.env_config(
-        ) or DEFAULT_DB_URI
+        self.mongo_uri = uri or self.get_mongo()
         self.username = None
         self.password = None
-        
+
         # 加入配置文件地址
+
+
+    def get_mongo(self):
+        config = configparser.ConfigParser()
+        if os.path.exists(CONFIGFILE_PATH):
+            config.read(CONFIGFILE_PATH)
+
+            try:
+                res = config.get('MONGODB', 'uri')
+            except:
+                res = DEFAULT_DB_URI
+
+        else:
+            config = configparser.ConfigParser()
+            config.add_section('MONGODB')
+            config.set('MONGODB', 'uri', 'mongodb://localhost:27017')
+            f = open('{}{}{}'.format(setting_path, os.sep, 'config.ini'), 'w')
+            config.write(f)
+            res = DEFAULT_DB_URI
+
+        return res
 
     def get_config(
             self,
@@ -72,28 +93,11 @@ class QA_Setting():
         """
 
         config = configparser.ConfigParser()
-        self.lock.acquire()
-        if os.path.exists(CONFIGFILE_PATH):
-            
-            config.read(CONFIGFILE_PATH)
-            self.lock.release()
-            return self.get_or_set_section(
-                config,
-                section,
-                option,
-                default_value
-            )
-
-            # 排除某些IP
-            # self.get_or_set_section(config, 'IPLIST', 'exclude', [{'ip': '1.1.1.1', 'port': 7709}])
-
+        res = self.client.usersetting.find_one({'section': section})
+        if res:
+            return res.get(option, default_value)
         else:
-            f = open(CONFIGFILE_PATH, 'w')
-            config.add_section(section)
-            config.set(section, option, default_value)
-            config.write(f)
-            f.close()
-            self.lock.release()
+            self.set_config(section, option, default_value)
             return default_value
 
     def set_config(
@@ -112,32 +116,35 @@ class QA_Setting():
         Returns:
             [type] -- [description]
         """
+        self.client.usersetting.update({'section': section,
+                                        {'$set': {
+                                            section: {
+                                                option: default_value
+                                            }}}}, upsert=True)
 
-        config = configparser.ConfigParser()
-        self.lock.acquire()
-        if os.path.exists(CONFIGFILE_PATH):
-            config.read(CONFIGFILE_PATH)
-            self.lock.release()
-            return self.get_or_set_section(
-                config,
-                section,
-                option,
-                default_value,
-                'set'
-            )
+        # if os.path.exists(CONFIGFILE_PATH):
+        #     config.read(CONFIGFILE_PATH)
+        #     self.lock.release()
+        #     return self.get_or_set_section(
+        #         config,
+        #         section,
+        #         option,
+        #         default_value,
+        #         'set'
+        #     )
 
-            # 排除某些IP
-            # self.get_or_set_section(config, 'IPLIST', 'exclude', [{'ip': '1.1.1.1', 'port': 7709}])
+        #     # 排除某些IP
+        #     # self.get_or_set_section(config, 'IPLIST', 'exclude', [{'ip': '1.1.1.1', 'port': 7709}])
 
-        else:
-            f = open(CONFIGFILE_PATH, 'w')
-            config.add_section(section)
-            config.set(section, option, default_value)
-            
-            config.write(f)
-            f.close()
-            self.lock.release()
-            return default_value
+        # else:
+        #     f = open(CONFIGFILE_PATH, 'w')
+        #     config.add_section(section)
+        #     config.set(section, option, default_value)
+
+        #     config.write(f)
+        #     f.close()
+        #     self.lock.release()
+        #     return default_value
 
     def get_or_set_section(
             self,
@@ -161,31 +168,21 @@ class QA_Setting():
         Returns:
             [type] -- [description]
         """
-        self.lock.acquire()
+
         try:
             if isinstance(DEFAULT_VALUE, str):
                 val = DEFAULT_VALUE
             else:
                 val = json.dumps(DEFAULT_VALUE)
             if method == 'get':
-                return config.get(section, option)
+                return self.get_config(section, option)
             else:
-                config.set(section, option, val)
+                self.set_config(section, option, val)
                 return val
 
-        except configparser.NoSectionError:
-            print('NO SECTION "{}" FOUND, Initialize...'.format(section))
-            config.add_section(section)
-            config.set(section, option, val)
+        except:
+            self.set_config(section, option, val)
             return val
-        except configparser.NoOptionError:
-            print('NO OPTION "{}" FOUND, Initialize...'.format(option))
-            config.set(section, option, val)
-            return val
-        finally:
-            with open(CONFIGFILE_PATH, 'w') as f:
-                config.write(f)
-            self.lock.release()
 
     def env_config(self):
         return os.environ.get("MONGOURI", None)
@@ -204,8 +201,6 @@ class QA_Setting():
         global DATABASE
         DATABASE = self.client
         return self
-
-
 
 
 QASETTING = QA_Setting()
@@ -228,6 +223,7 @@ def exclude_from_stock_ip_list(exclude_ip_list):
     for exc in exclude_ip_list:
         if exc in future_ip_list:
             future_ip_list.remove(exc)
+
 
 if os.path.exists(INFO_IP_FILE_PATH):
     with open(INFO_IP_FILE_PATH, "r") as f:
@@ -265,8 +261,8 @@ else:
         {"ip": "47.107.75.159", "port": 7711, "name": "深圳双线资讯主站4"},
         {"ip": "47.92.127.181", "port": 7711, "name": "北京双线资讯主站"},
 
-        {"ip":"113.105.142.162","port":7721},
-        {"ip":"23.129.245.199","port":7721},
+        {"ip": "113.105.142.162", "port": 7721},
+        {"ip": "23.129.245.199", "port": 7721},
 
     ]
     with open(INFO_IP_FILE_PATH, "w") as f:

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -72,8 +72,11 @@ class QA_Setting():
         """
 
         config = configparser.ConfigParser()
+        self.lock.acquire()
         if os.path.exists(CONFIGFILE_PATH):
+            
             config.read(CONFIGFILE_PATH)
+            self.lock.release()
             return self.get_or_set_section(
                 config,
                 section,
@@ -85,7 +88,6 @@ class QA_Setting():
             # self.get_or_set_section(config, 'IPLIST', 'exclude', [{'ip': '1.1.1.1', 'port': 7709}])
 
         else:
-            self.lock.acquire()
             f = open(CONFIGFILE_PATH, 'w')
             config.add_section(section)
             config.set(section, option, default_value)
@@ -112,8 +114,10 @@ class QA_Setting():
         """
 
         config = configparser.ConfigParser()
+        self.lock.acquire()
         if os.path.exists(CONFIGFILE_PATH):
             config.read(CONFIGFILE_PATH)
+            self.lock.release()
             return self.get_or_set_section(
                 config,
                 section,
@@ -129,8 +133,10 @@ class QA_Setting():
             f = open(CONFIGFILE_PATH, 'w')
             config.add_section(section)
             config.set(section, option, default_value)
+            
             config.write(f)
             f.close()
+            self.lock.release()
             return default_value
 
     def get_or_set_section(
@@ -155,7 +161,7 @@ class QA_Setting():
         Returns:
             [type] -- [description]
         """
-
+        self.lock.acquire()
         try:
             if isinstance(DEFAULT_VALUE, str):
                 val = DEFAULT_VALUE
@@ -177,7 +183,6 @@ class QA_Setting():
             config.set(section, option, val)
             return val
         finally:
-            self.lock.acquire()
             with open(CONFIGFILE_PATH, 'w') as f:
                 config.write(f)
             self.lock.release()

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -114,7 +114,6 @@ class QA_Setting():
         Returns:
             [type] -- [description]
         """
-        print({section: {option: default_value}})
         t = {'section': section, option: default_value}
         self.client.quantaxis.usersetting.update(
             {'section': section}, {'$set':t}, upsert=True)

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -54,7 +54,6 @@ class QA_Setting():
 
         # 加入配置文件地址
 
-
     def get_mongo(self):
         config = configparser.ConfigParser()
         if os.path.exists(CONFIGFILE_PATH):
@@ -92,8 +91,7 @@ class QA_Setting():
             [type] -- [description]
         """
 
-        config = configparser.ConfigParser()
-        res = self.client.usersetting.find_one({'section': section})
+        res = self.client.quantaxis.usersetting.find_one({'section': section})
         if res:
             return res.get(option, default_value)
         else:
@@ -116,11 +114,10 @@ class QA_Setting():
         Returns:
             [type] -- [description]
         """
-        self.client.usersetting.update({'section': section,
-                                        {'$set': {
-                                            section: {
-                                                option: default_value
-                                            }}}}, upsert=True)
+        print({section: {option: default_value}})
+        t = {'section': section, option: default_value}
+        self.client.quantaxis.usersetting.update(
+            {'section': section}, {'$set':t}, upsert=True)
 
         # if os.path.exists(CONFIGFILE_PATH):
         #     config.read(CONFIGFILE_PATH)

--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -46,12 +46,12 @@ FUTURE_IP_FILE_PATH = '{}{}{}'.format(setting_path, os.sep, 'future_ip.json')
 class QA_Setting():
 
     def __init__(self, uri=None):
+        self.lock = Lock()
         self.mongo_uri = uri or self.get_config() or self.env_config(
         ) or DEFAULT_DB_URI
         self.username = None
         self.password = None
-        self.lock = Lock()
-
+        
         # 加入配置文件地址
 
     def get_config(

--- a/QUANTAXIS/QAUtil/QASql.py
+++ b/QUANTAXIS/QAUtil/QASql.py
@@ -25,7 +25,6 @@
 import pymongo
 from motor.motor_asyncio import AsyncIOMotorClient
 from motor import MotorClient
-from QUANTAXIS.QAUtil.QALogs import QA_util_log_info
 import asyncio
 
 

--- a/QUANTAXIS/__init__.py
+++ b/QUANTAXIS/__init__.py
@@ -31,7 +31,7 @@ by yutiansut
 2017/4/8
 """
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 __author__ = 'yutiansut'
 
 # fetch methods

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
     ],
-    scripts=['make_config'],
     install_requires=['pandas>=0.23.4', 'numpy>=1.12.0', 'tushare', 'flask_socketio>=2.9.0 ', 'motor>=1.1', 'seaborn>=0.8.1', 'pyconvert>=0.6.3',
                       'lxml>=4.0', ' beautifulsoup4', 'matplotlib', 'requests', 'tornado',
                       'demjson>=2.2.4', 'pymongo>=3.7', 'six>=1.10.0', 'tabulate>=0.7.7', 'pytdx>=1.67', 'retrying>=1.3.3',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import re
 import sys
 import webbrowser
 import platform
-
+import configparser
 try:
     from setuptools import setup
 except:
@@ -65,7 +65,7 @@ NAME = "quantaxis"
 """
 
 """
-PACKAGES = ["QUANTAXIS", "QUANTAXIS.QAFetch", "QUANTAXIS.QACmd", "QUANTAXIS.QAMarket", 'QUANTAXIS.QASetting',"QUANTAXIS.QACmd",
+PACKAGES = ["QUANTAXIS", "QUANTAXIS.QAFetch", "QUANTAXIS.QACmd", "QUANTAXIS.QAMarket", 'QUANTAXIS.QASetting', "QUANTAXIS.QACmd",
             "QUANTAXIS.QAApplication", "QUANTAXIS.QAEngine", "QUANTAXIS.QAData", 'QUANTAXIS.QAData.proto', "QUANTAXIS.QAAnalysis", 'QUANTAXIS.QASelector',
             "QUANTAXIS.QASU", "QUANTAXIS.QAUtil", "QUANTAXIS.QAARP", "QUANTAXIS.QAIndicator"]
 """
@@ -93,6 +93,9 @@ URL = "https://github.com/quantaxis/quantaxis"
 
 LICENSE = "MIT"
 
+
+
+
 setup(
     name=NAME,
     version=VERSION,
@@ -104,6 +107,7 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
     ],
+    scripts=['make_config'],
     install_requires=['pandas>=0.23.4', 'numpy>=1.12.0', 'tushare', 'flask_socketio>=2.9.0 ', 'motor>=1.1', 'seaborn>=0.8.1', 'pyconvert>=0.6.3',
                       'lxml>=4.0', ' beautifulsoup4', 'matplotlib', 'requests', 'tornado',
                       'demjson>=2.2.4', 'pymongo>=3.7', 'six>=1.10.0', 'tabulate>=0.7.7', 'pytdx>=1.67', 'retrying>=1.3.3',
@@ -125,5 +129,3 @@ setup(
     include_package_data=True,
     zip_safe=True
 )
-
-


### PR DESCRIPTION
众所周知 多进程的读写会出现bug

在初步尝试了  ThreadLock 和 multiprocessing.Lock以后 我决定放弃使用加锁来进行控制， 而是转为取消在多进程的时候的写入过程， 并考虑将部分中间数据放入mongodb,依赖mongodb的全局读写锁来解决问题


@Carltiger 他的方法https://github.com/QUANTAXIS/QUANTAXIS/pull/986 我不是很认同 每次都clear config的话 还不如不写config全部使用默认值