### PR TITLE
修改中断形式

### DIFF
--- a/QUANTAXIS/QAFetch/QATdx_adv.py
+++ b/QUANTAXIS/QAFetch/QATdx_adv.py
@@ -64,13 +64,15 @@ class QA_Tdx_Executor():
             func = api.__getattribute__(item)
 
             def wrapper(*args, **kwargs):
-                _time = datetime.datetime.now()
-                res = self.executor.submit(func, *args, **kwargs)
-                used_time = (datetime.datetime.now() - _time).total_seconds()
-
-                #IP延迟低，放进队列继续使用
-                if used_time < self.timeout*2:
-                    self._queue.put(api)
+                try:
+                    _time = datetime.datetime.now()
+                    res = self.executor.submit(func, *args, **kwargs)
+                    used_time = (datetime.datetime.now() - _time).total_seconds()
+                    #IP延迟低，放进队列继续使用
+                    if used_time < self.timeout*2:
+                        self._queue.put(api)
+                except:
+                    pass
                 return res
             return wrapper
         except:

--- a/QUANTAXIS/QAFetch/QATdx_adv.py
+++ b/QUANTAXIS/QAFetch/QATdx_adv.py
@@ -72,7 +72,7 @@ class QA_Tdx_Executor():
                     if used_time < self.timeout*2:
                         self._queue.put(api)
                 except:
-                    pass
+                    raise Exception('多线程里有异常，重新执行')
                 return res
             return wrapper
         except:

--- a/QUANTAXIS/QAFetch/QATdx_adv.py
+++ b/QUANTAXIS/QAFetch/QATdx_adv.py
@@ -148,7 +148,7 @@ class QA_Tdx_Executor():
         random.shuffle(ip_list)
         for item in ip_list:
             if self._queue.full():
-                break
+                return
             _sec = self._test_speed(ip=item['ip'], port=item['port'])
             if _sec < self.timeout*3:
                 try:


### PR DESCRIPTION
优化QA_Tdx_Executor清理垃圾IP的方式
修正当网络不好时ip列表达到max_size卡住的bug
将IP列表随机排序，避免只使用列表前面的IP地址
调整realtime_xxxxxxxx的索引方式，大幅提升QA_fetch_stock_realtime_adv取数据性能