### PR TITLE
adapt QA_SU_save_stock_day for the latest version of tushare

### DIFF
--- a/QUANTAXIS/QACmd/__init__.py
+++ b/QUANTAXIS/QACmd/__init__.py
@@ -273,7 +273,7 @@ class CLI(cmd.Cmd):
                         }
                     )
                 # TODO: 将ts还是tdx作为命令传入
-                #QA_SU_save_stock_day('ts')
+                # QA_SU_save_stock_day('ts')
                 QA_SU_save_stock_day('tdx')
                 QA_SU_save_stock_xdxr('tdx')
                 # QA_SU_save_stock_min('tdx')

--- a/QUANTAXIS/QACmd/__init__.py
+++ b/QUANTAXIS/QACmd/__init__.py
@@ -272,6 +272,8 @@ class CLI(cmd.Cmd):
                             'password': 'admin'
                         }
                     )
+                # TODO: 将ts还是tdx作为命令传入
+                #QA_SU_save_stock_day('ts')
                 QA_SU_save_stock_day('tdx')
                 QA_SU_save_stock_xdxr('tdx')
                 # QA_SU_save_stock_min('tdx')

--- a/QUANTAXIS/QAFetch/QATushare.py
+++ b/QUANTAXIS/QAFetch/QATushare.py
@@ -117,7 +117,7 @@ def cover_time(date):
     return date
 
 
-def QA_fetch_get_stock_day(name, start='', end='', if_fq='qfq', type_='pd'):
+def _get_subscription_type(if_fq):
     if str(if_fq) in ['qfq', '01']:
         if_fq = 'qfq'
     elif str(if_fq) in ['hfq', '02']:
@@ -127,6 +127,11 @@ def QA_fetch_get_stock_day(name, start='', end='', if_fq='qfq', type_='pd'):
     else:
         QA_util_log_info('wrong with fq_factor! using qfq')
         if_fq = 'qfq'
+    return if_fq
+
+
+def QA_fetch_get_stock_day(name, start='', end='', if_fq='qfq', type_='pd'):
+    if_fq = _get_subscription_type(if_fq)
 
     def fetch_data():
         data = None

--- a/QUANTAXIS/QAFetch/QATushare.py
+++ b/QUANTAXIS/QAFetch/QATushare.py
@@ -96,11 +96,11 @@ def QA_fetch_stock_basic():
                 'name,'
                 'area,industry,list_date'
             )
-        except:
+        except Exception as e:
+            print(e)
             print('except when fetch stock basic')
             time.sleep(1)
             stock_basic = fetch_stock_basic()
-        print(stock_basic)
         return stock_basic
 
     return fetch_stock_basic()
@@ -194,8 +194,8 @@ def QA_fetch_get_stock_list():
 
 def QA_fetch_get_stock_time_to_market():
     data = ts.get_stock_basics()
-    return data[data['timeToMarket'] != 0
-               ]['timeToMarket'].apply(lambda x: QA_util_date_int2str(x))
+    return data[data['timeToMarket'] != 0]['timeToMarket']\
+        .apply(lambda x: QA_util_date_int2str(x))
 
 
 def QA_fetch_get_trade_date(end, exchange):

--- a/QUANTAXIS/QAFetch/QATushare.py
+++ b/QUANTAXIS/QAFetch/QATushare.py
@@ -26,8 +26,14 @@ import json
 import pandas as pd
 import tushare as ts
 import time
-from QUANTAXIS.QAUtil import (QA_util_date_int2str, QA_util_date_stamp, QASETTING,
-                              QA_util_log_info, QA_util_to_json_from_pandas)
+from QUANTAXIS.QAUtil import (
+    QA_util_date_int2str,
+    QA_util_date_stamp,
+    QASETTING,
+    QA_util_log_info,
+    QA_util_to_json_from_pandas
+)
+
 
 def set_token(token=None):
     try:
@@ -71,29 +77,34 @@ def QA_fetch_get_stock_adj(code, end=''):
         [type] -- [description]
     """
 
-
     pro = get_pro()
     adj = pro.adj_factor(ts_code=code, trade_date=end)
     return adj
 
+
 def QA_fetch_stock_basic():
+
     def fetch_stock_basic():
         stock_basic = None
         try:
             pro = get_pro()
-            stock_basic = pro.stock_basic(exchange='',
-                                          list_status='L',
-                                          fields='ts_code,'
-                                                 'symbol,'
-                                                 'name,'
-                                                 'area,industry,list_date')
+            stock_basic = pro.stock_basic(
+                exchange='',
+                list_status='L',
+                fields='ts_code,'
+                'symbol,'
+                'name,'
+                'area,industry,list_date'
+            )
         except:
             print('except when fetch stock basic')
             time.sleep(1)
             stock_basic = fetch_stock_basic()
         print(stock_basic)
         return stock_basic
+
     return fetch_stock_basic()
+
 
 def cover_time(date):
     """
@@ -105,11 +116,8 @@ def cover_time(date):
     date = time.mktime(time.strptime(datestr, '%Y%m%d'))
     return date
 
-def QA_fetch_get_stock_day(name,
-                           start='',
-                           end='',
-                           if_fq='qfq',
-                           type_='pd'):
+
+def QA_fetch_get_stock_day(name, start='', end='', if_fq='qfq', type_='pd'):
     if str(if_fq) in ['qfq', '01']:
         if_fq = 'qfq'
     elif str(if_fq) in ['hfq', '02']:
@@ -119,25 +127,31 @@ def QA_fetch_get_stock_day(name,
     else:
         QA_util_log_info('wrong with fq_factor! using qfq')
         if_fq = 'qfq'
+
     def fetch_data():
         data = None
         try:
             time.sleep(0.002)
             pro = get_pro()
-            data = ts.pro_bar(pro_api=pro,
-                              ts_code=str(name),
-                              asset='E',
-                              adj=if_fq,
-                              start_date=start,
-                              end_date=end,
-                              freq='D',
-                              factors=['tor', 'vr']).sort_index()
+            data = ts.pro_bar(
+                pro_api=pro,
+                ts_code=str(name),
+                asset='E',
+                adj=if_fq,
+                start_date=start,
+                end_date=end,
+                freq='D',
+                factors=['tor',
+                         'vr']
+            ).sort_index()
             print('fetch done: ' + str(name))
-        except:
+        except Exception as e:
+            print(e)
             print('except when fetch data of ' + str(name))
             time.sleep(1)
             data = fetch_data()
         return data
+
     data = fetch_data()
 
     data['date_stamp'] = data['trade_date'].apply(lambda x: cover_time(x))
@@ -177,9 +191,11 @@ def QA_fetch_get_stock_list():
     df = QA_fetch_stock_basic()
     return list(df.ts_code)
 
+
 def QA_fetch_get_stock_time_to_market():
     data = ts.get_stock_basics()
-    return data[data['timeToMarket'] != 0]['timeToMarket'].apply(lambda x: QA_util_date_int2str(x))
+    return data[data['timeToMarket'] != 0
+               ]['timeToMarket'].apply(lambda x: QA_util_date_int2str(x))
 
 
 def QA_fetch_get_trade_date(end, exchange):
@@ -192,15 +208,18 @@ def QA_fetch_get_trade_date(end, exchange):
         num = i + 1
         exchangeName = 'SSE'
         data_stamp = QA_util_date_stamp(date)
-        mes = {'date': date, 'num': num,
-               'exchangeName': exchangeName, 'date_stamp': data_stamp}
+        mes = {
+            'date': date,
+            'num': num,
+            'exchangeName': exchangeName,
+            'date_stamp': data_stamp
+        }
         message.append(mes)
     return message
 
 
 def QA_fetch_get_lhb(date):
     return ts.top_list(date)
-
 
 
 def QA_fetch_get_stock_money():

--- a/QUANTAXIS/QAFetch/QATushare.py
+++ b/QUANTAXIS/QAFetch/QATushare.py
@@ -25,20 +25,23 @@
 import json
 import pandas as pd
 import tushare as ts
-
+import time
 from QUANTAXIS.QAUtil import (QA_util_date_int2str, QA_util_date_stamp, QASETTING,
                               QA_util_log_info, QA_util_to_json_from_pandas)
-
 
 def set_token(token=None):
     try:
         if token is None:
+            # 从~/.quantaxis/setting/config.ini中读取配置
             token = QASETTING.get_config('TSPRO', 'token', None)
         else:
             QASETTING.set_config('TSPRO', 'token', token)
         ts.set_token(token)
     except:
-        print('请升级tushare 至最新版本 pip install tushare -U')
+        if token is None:
+            print('请设置tushare的token')
+        else:
+            print('请升级tushare 至最新版本 pip install tushare -U')
 
 
 def get_pro():
@@ -73,11 +76,40 @@ def QA_fetch_get_stock_adj(code, end=''):
     adj = pro.adj_factor(ts_code=code, trade_date=end)
     return adj
 
+def QA_fetch_stock_basic():
+    def fetch_stock_basic():
+        stock_basic = None
+        try:
+            pro = get_pro()
+            stock_basic = pro.stock_basic(exchange='',
+                                          list_status='L',
+                                          fields='ts_code,'
+                                                 'symbol,'
+                                                 'name,'
+                                                 'area,industry,list_date')
+        except:
+            print('except when fetch stock basic')
+            time.sleep(1)
+            stock_basic = fetch_stock_basic()
+        print(stock_basic)
+        return stock_basic
+    return fetch_stock_basic()
 
-def QA_fetch_get_stock_day(name, start='', end='', if_fq='01', type_='pd'):
-    if (len(name) != 6):
-        name = str(name)[0:6]
+def cover_time(date):
+    """
+    字符串 '20180101'  转变成 float 类型时间 类似 time.time() 返回的类型
+    :param date: 字符串str -- 格式必须是 20180101 ，长度8
+    :return: 类型float
+    """
+    datestr = str(date)[0:8]
+    date = time.mktime(time.strptime(datestr, '%Y%m%d'))
+    return date
 
+def QA_fetch_get_stock_day(name,
+                           start='',
+                           end='',
+                           if_fq='qfq',
+                           type_='pd'):
     if str(if_fq) in ['qfq', '01']:
         if_fq = 'qfq'
     elif str(if_fq) in ['hfq', '02']:
@@ -87,17 +119,35 @@ def QA_fetch_get_stock_day(name, start='', end='', if_fq='01', type_='pd'):
     else:
         QA_util_log_info('wrong with fq_factor! using qfq')
         if_fq = 'qfq'
+    def fetch_data():
+        data = None
+        try:
+            time.sleep(0.002)
+            pro = get_pro()
+            data = ts.pro_bar(pro_api=pro,
+                              ts_code=str(name),
+                              asset='E',
+                              adj=if_fq,
+                              start_date=start,
+                              end_date=end,
+                              freq='D',
+                              factors=['tor', 'vr']).sort_index()
+            print('fetch done: ' + str(name))
+        except:
+            print('except when fetch data of ' + str(name))
+            time.sleep(1)
+            data = fetch_data()
+        return data
+    data = fetch_data()
 
-    data = ts.get_k_data(str(name), start, end, ktype='D',
-                         autype=if_fq, retry_count=200, pause=0.005).sort_index()
-
-    data['date_stamp'] = data['date'].apply(lambda x: QA_util_date_stamp(x))
+    data['date_stamp'] = data['trade_date'].apply(lambda x: cover_time(x))
+    data['code'] = data['ts_code'].apply(lambda x: str(x)[0:6])
     data['fqtype'] = if_fq
     if type_ in ['json']:
         data_json = QA_util_to_json_from_pandas(data)
         return data_json
     elif type_ in ['pd', 'pandas', 'p']:
-        data['date'] = pd.to_datetime(data['date'])
+        data['date'] = pd.to_datetime(data['trade_date'], format='%Y%m%d')
         data = data.set_index('date', drop=False)
         data['date'] = data['date'].apply(lambda x: str(x)[0:10])
         return data
@@ -124,9 +174,8 @@ def QA_fetch_get_stock_tick(name, date):
 
 
 def QA_fetch_get_stock_list():
-    df = ts.get_stock_basics()
-    return list(df.index)
-
+    df = QA_fetch_stock_basic()
+    return list(df.ts_code)
 
 def QA_fetch_get_stock_time_to_market():
     data = ts.get_stock_basics()
@@ -162,3 +211,6 @@ def QA_fetch_get_stock_money():
 
 # print(get_stock_day("000001",'2001-01-01','2010-01-01'))
 # print(get_stock_tick("000001.SZ","2017-02-21"))
+if __name__ == '__main__':
+    df = QA_fetch_get_stock_list()
+    print(df)

--- a/QUANTAXIS/QASU/save_tushare.py
+++ b/QUANTAXIS/QASU/save_tushare.py
@@ -26,6 +26,7 @@ import datetime
 import json
 import re
 import time
+import pymongo
 
 import tushare as ts
 
@@ -36,12 +37,27 @@ from QUANTAXIS.QAFetch.QATushare import (QA_fetch_get_stock_day,
                                          QA_fetch_get_lhb)
 from QUANTAXIS.QAUtil import (QA_util_date_stamp, QA_util_log_info,
                               QA_util_time_stamp, QA_util_to_json_from_pandas,
-                              trade_date_sse)
+                              trade_date_sse, QA_util_get_real_date,
+                              QA_util_get_next_day)
 from QUANTAXIS.QAUtil.QASetting import DATABASE
 
 
 import tushare as QATs
 
+def date_conver_to_new_format(date_str):
+    time_now = time.strptime(date_str[0:10], '%Y-%m-%d')
+    return '{:0004}{:02}{:02}'.format(int(time_now.tm_year),
+                                      int(time_now.tm_mon),
+                                      int(time_now.tm_mday))
+
+# TODO: 和sav_tdx.py中的now_time一起提取成公共函数
+def now_time():
+    str_now = str(QA_util_get_real_date(str(datetime.date.today() - datetime.timedelta(days=1)),
+                                            trade_date_sse, -1)) + \
+                    ' 17:00:00' if datetime.datetime.now().hour < 15 else str(QA_util_get_real_date(
+                        str(datetime.date.today()), trade_date_sse, -1)) + ' 15:00:00'
+
+    return date_conver_to_new_format(str_now)
 
 def QA_save_stock_day_all(client=DATABASE):
     df = ts.get_stock_basics()
@@ -163,10 +179,10 @@ def QA_save_stock_day_all_bfq(client=DATABASE):
     def saving_work(i):
         QA_util_log_info('Now Saving ==== %s' % (i))
         try:
-            data_json = QA_fetch_get_stock_day(
-                i, start='1990-01-01', if_fq='00')
+            df = QA_fetch_get_stock_day(
+                i, start='1990-01-01', if_fq='bfq')
 
-            __coll.insert_many(data_json)
+            __coll.insert_many(json.loads(df.to_json(orient='records')))
         except:
             QA_util_log_info('error in saving ==== %s' % str(i))
 
@@ -241,6 +257,116 @@ def QA_save_lhb(client=DATABASE):
             time.sleep(2)
             continue
 
+def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
+    '''
+     save stock_day
+    保存日线数据
+    :param client:
+    :param ui_log:  给GUI qt 界面使用
+    :param ui_progress: 给GUI qt 界面使用
+    :param ui_progress_int_value: 给GUI qt 界面使用
+    '''
+    stock_list = QA_fetch_get_stock_list()
+    # TODO: 重命名stock_day_ts
+    coll_stock_day = client.stock_day_ts
+    coll_stock_day.create_index(
+        [("code",
+          pymongo.ASCENDING),
+         ("date_stamp",
+          pymongo.ASCENDING)]
+    )
+    err = []
+
+    def __saving_work(code, coll_stock_day):
+        try:
+            QA_util_log_info(
+                '##JOB01 Now Saving STOCK_DAY==== {}'.format(str(code)),
+                ui_log
+            )
+
+            # 首选查找数据库 是否 有 这个代码的数据
+            ref = coll_stock_day.find({'code': str(code)[0:9]})
+            end_date = now_time()
+
+            # 当前数据库已经包含了这个代码的数据， 继续增量更新
+            # 加入这个判断的原因是因为如果股票是刚上市的 数据库会没有数据 所以会有负索引问题出现
+            if ref.count() > 0:
+
+                # 接着上次获取的日期继续更新
+                start_date_new_format = ref[ref.count() - 1]['trade_date']
+                start_date = ref[ref.count() - 1]['date']
+
+                QA_util_log_info(
+                    'UPDATE_STOCK_DAY \n Trying updating {} from {} to {}'
+                    .format(code,
+                            start_date,
+                            end_date),
+                    ui_log
+                )
+                if start_date_new_format != end_date:
+                    coll_stock_day.insert_many(
+                        QA_util_to_json_from_pandas(
+                            QA_fetch_get_stock_day(
+                                str(code),
+                                date_conver_to_new_format(QA_util_get_next_day(start_date)),
+                                end_date,
+                                'qfq'
+                            )
+                        )
+                    )
+
+            # 当前数据库中没有这个代码的股票数据， 从1990-01-01 开始下载所有的数据
+            else:
+                start_date = '19900101'
+                QA_util_log_info(
+                    'UPDATE_STOCK_DAY \n Trying updating {} from {} to {}'
+                    .format(code,
+                            start_date,
+                            end_date),
+                    ui_log
+                )
+                if start_date != end_date:
+                    coll_stock_day.insert_many(
+                        QA_util_to_json_from_pandas(
+                            QA_fetch_get_stock_day(
+                                str(code),
+                                start_date,
+                                end_date,
+                                'qfq'
+                            )
+                        )
+                    )
+        except Exception as error0:
+            print(error0)
+            err.append(str(code))
+
+    num_stocks = len(stock_list)
+    for index, ts_code in enumerate(stock_list):
+        QA_util_log_info('The {} of Total {}'.format(index, num_stocks))
+
+        strProgressToLog = 'DOWNLOAD PROGRESS {} {}'.format(
+            str(float(index / num_stocks * 100))[0:4] + '%',
+            ui_log
+        )
+        intProgressToLog = int(float(index / num_stocks * 100))
+        QA_util_log_info(
+            strProgressToLog,
+            ui_log=ui_log,
+            ui_progress=ui_progress,
+            ui_progress_int_value=intProgressToLog
+        )
+        __saving_work(ts_code, coll_stock_day)
+        # 日线行情每分钟内最多调取200次，超过5000积分无限制
+        time.sleep(0.005)
+
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS save stock day ^_^', ui_log)
+    else:
+        QA_util_log_info('ERROR CODE \n ', ui_log)
+        QA_util_log_info(err, ui_log)
 
 if __name__ == '__main__':
-    QA_save_lhb()
+    from pymongo import MongoClient
+    client = MongoClient('localhost', 27017)
+    db = client['quantaxis']
+    QA_SU_save_stock_day(client=db)

--- a/QUANTAXIS/QASU/save_tushare.py
+++ b/QUANTAXIS/QASU/save_tushare.py
@@ -62,12 +62,12 @@ def date_conver_to_new_format(date_str):
 
 # TODO: 和sav_tdx.py中的now_time一起提取成公共函数
 def now_time():
-    str_now = str(QA_util_get_real_date(str(datetime.date.today() - \
+    real_date = str(QA_util_get_real_date(str(datetime.date.today() -
                                             datetime.timedelta(days=1)),
-                                        trade_date_sse, -1)) + \
-                    ' 17:00:00' if datetime.datetime.now().hour < 15 \
-                    else str(QA_util_get_real_date(str(datetime.date.today()),
-                                                   trade_date_sse, -1)) + ' 15:00:00'
+                                        trade_date_sse, -1))
+    str_now = real_date + ' 17:00:00' if datetime.datetime.now().hour < 15 \
+        else str(QA_util_get_real_date(str(datetime.date.today()),
+                                       trade_date_sse, -1)) + ' 15:00:00'
 
     return date_conver_to_new_format(str_now)
 

--- a/QUANTAXIS/QASU/save_tushare.py
+++ b/QUANTAXIS/QASU/save_tushare.py
@@ -299,7 +299,7 @@ def QA_save_lhb(client=DATABASE):
             continue
 
 
-def _saving_work(code, coll_stock_day, ui_log=None):
+def _saving_work(code, coll_stock_day, ui_log=None, err=[]):
     try:
         QA_util_log_info(
             '##JOB01 Now Saving STOCK_DAY==== {}'.format(str(code)),
@@ -362,6 +362,7 @@ def _saving_work(code, coll_stock_day, ui_log=None):
                 )
     except Exception as e:
         print(e)
+        err.append(str(code))
 
 
 def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
@@ -383,6 +384,7 @@ def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
           pymongo.ASCENDING)]
     )
 
+    err = []
     num_stocks = len(stock_list)
     for index, ts_code in enumerate(stock_list):
         QA_util_log_info('The {} of Total {}'.format(index, num_stocks))
@@ -398,7 +400,10 @@ def QA_SU_save_stock_day(client=DATABASE, ui_log=None, ui_progress=None):
             ui_progress=ui_progress,
             ui_progress_int_value=intProgressToLog
         )
-        _saving_work(ts_code, coll_stock_day, ui_log=ui_log)
+        _saving_work(ts_code,
+                     coll_stock_day,
+                     ui_log=ui_log,
+                     err=err)
         # 日线行情每分钟内最多调取200次，超过5000积分无限制
         time.sleep(0.005)
 


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
默认得通过tdx下载股票日线获得的数据缺少换手率等数据，通过算交叉熵等统计方式发现，换手率等与交易量相关的指标对预测涨跌有较大帮助。
然而，通过tdx下载的数据中，没有历史的流通股数据，所以根据现有数据无法计算获得换手率指标。
原有代码可通过tushare老的接口获得换手率指标，但老接口不再维护，故需适配新接口。
该PR实现的功能如下：
1.适配函数QA_SU_save_stock_day，实现通过最新的tushre接口下载股票日线数据，并存到mongodb的stock_day_ts中。
因未经过讨论，所以该PR经适配了QA_SU_save_stock_day('ts')，但未在save all中启用，并且字段也未与回测框架进行适配和验证。后续有需要可以讨论并完成这部分工作。



作者信息: Breath123
时间: 2019/4/21
