### PR TITLE
#update AccPro

### DIFF
--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -1657,9 +1657,10 @@ class QA_AccountPRO(QA_Worker):
         self.frozen = message.get('frozen', {})
         self.finishedOrderid = message.get('finished_id', [])
         pos_id = message.get('position_id', [])
+        print(pos_id)
         self.pms = dict(zip(pos_id, [QA_Position(position_id=item,
                                                  account_cookie=self.account_cookie, portfolio_cookie=self.portfolio_cookie,
-                                                 user_cookie=self.user_cookie) for item in pos_id]))
+                                                 user_cookie=self.user_cookie, auto_reload=True) for item in pos_id]))
 
         self.settle()
         return self
@@ -1825,9 +1826,15 @@ class QA_AccountPRO(QA_Worker):
 
     def get_holddetail(self, code):
         try:
-            return self.hold_detail.loc[(code, slice(None))].sum().to_dict()
+            return self.hold_detail.loc[code].to_dict()
         except KeyError:
-            return {'volume_long': 0, 'volume_short': 0}
+            return {'volume_long': 0,
+                    'volume_long_his': 0,
+                    'volume_long_today': 0,
+                    'volume_short': 0,
+                    'volume_short_his': 0,
+                    'volume_short_today': 0}
+
 
     def save(self):
         """

--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -64,6 +64,8 @@ class QA_AccountPRO(QA_Worker):
 
     QAAccount
 
+    在QAAccountPro/Position的模型中, Pos不负责OMS业务,因此, 需要使用AccPro的sendOrder来主导OMS模型
+
     """
 
     def __init__(
@@ -1789,7 +1791,7 @@ class QA_AccountPRO(QA_Worker):
         """
         存储账户信息
         """
-        save_account(self.message)
+        save_account(self.message, self.client)
 
     def reload(self):
 

--- a/QUANTAXIS/QAMarket/QAPosition.py
+++ b/QUANTAXIS/QAMarket/QAPosition.py
@@ -70,7 +70,7 @@ class QA_Position():
                  portfolio_cookie='portfolio',
                  user_cookie='quantaxis',
                  moneypreset=100000,  # 初始分配资金
-                 frozen = None,
+                 frozen=None,
                  moneypresetLeft=None,
                  volume_long_today=0,
                  volume_long_his=0,
@@ -167,7 +167,7 @@ class QA_Position():
         self.orders = {} if orders is None else orders
         self.frozen = {} if frozen is None else frozen
         if auto_reload:
-            self.save()
+            self.reload()
         self.allow_exceed = allow_exceed
 
     def __repr__(self):
@@ -355,6 +355,18 @@ class QA_Position():
         }
 
     @property
+    def hold_detail(self):
+        return {
+            # 持仓量
+            'volume_long_today': self.volume_long_today,
+            'volume_long_his': self.volume_long_his,
+            'volume_long': self.volume_long,
+            'volume_short_today': self.volume_short_today,
+            'volume_short_his': self.volume_short_his,
+            'volume_short': self.volume_short
+        }
+
+    @property
     def realtime_message(self):
         return {
             # 扩展字段
@@ -420,7 +432,7 @@ class QA_Position():
                                        1)
             ) * float(self.market_preset.get('buy_frozen_coeff',
                                              1))
-    
+
             if (self.moneypresetLeft > moneyneed) or self.allow_exceed:
                 self.moneypresetLeft -= moneyneed
                 self.frozen[order_id] = moneyneed
@@ -658,7 +670,7 @@ class QA_Position():
     def reload(self):
         res = DATABASE.positions.find_one({
             'account_cookie': self.account_cookie,
-            'portfolio_coookie': self.portfolio_cookie,
+            'portfolio_cookie': self.portfolio_cookie,
             'user_cookie': self.user_cookie,
             'position_id': self.position_id
         })
@@ -671,7 +683,7 @@ class QA_Position():
         self.__init__(
             code=message['code'],
             account_cookie=message['account_cookie'],
-            frozen = message['frozen'],
+            frozen=message['frozen'],
             portfolio_cookie=message['portfolio_cookie'],
             user_cookie=message['user_cookie'],
             moneypreset=message['moneypreset'],  # 初始分配资金
@@ -715,18 +727,18 @@ class QA_Position():
 
         - 交易过程的外部手动交易
         - 风控状态下的监控外部交易
-        
+
         order_id 是外部的
         trade_id 不一定存在
         """
 
         if order['order_id'] not in self.frozen.keys():
             print('OUTSIDE ORDER')
-            #self.frozen[order['order_id']] = order[]
+            # self.frozen[order['order_id']] = order[]
             # 回放订单/注册进订单系统
             order = self.send_order(
                 order.get('amount', order.get('volume')),
-                order['price'], 
+                order['price'],
                 eval('ORDER_DIRECTION.{}_{}'.format(
                     order.get('direction'),
                     order.get('offset')
@@ -754,9 +766,9 @@ class QA_Position():
                                 transaction.get('volume')),
                 towards
             )
-            self.moneypresetLeft+= self.frozen.get(transaction['order_id'],0)
+            self.moneypresetLeft += self.frozen.get(transaction['order_id'], 0)
             # 当出现外部交易的时候, 直接在frozen中注册订单
-            self.frozen[transaction['order_id']] =0
+            self.frozen[transaction['order_id']] = 0
             self.orders[transaction['order_id']] = ORDER_STATUS.SUCCESS_ALL
             self.trades.append(transaction)
         except Exception as e:

--- a/QUANTAXIS/QAMarket/QAPosition.py
+++ b/QUANTAXIS/QAMarket/QAPosition.py
@@ -101,6 +101,7 @@ class QA_Position():
                  orders=None,
                  name=None,
                  auto_reload=False,
+                 allow_exceed=False,
                  *args,
                  **kwargs
 
@@ -166,6 +167,7 @@ class QA_Position():
         self.frozen = {} if frozen is None else frozen
         if auto_reload:
             self.save()
+        self.allow_exceed = allow_exceed
 
     def __repr__(self):
         return '< QAPOSITION {} amount {}/{} >'.format(
@@ -417,7 +419,8 @@ class QA_Position():
                                        1)
             ) * float(self.market_preset.get('buy_frozen_coeff',
                                              1))
-            if self.moneypresetLeft > moneyneed:
+    
+            if (self.moneypresetLeft > moneyneed) or self.allow_exceed:
                 self.moneypresetLeft -= moneyneed
                 self.frozen[order_id] = moneyneed
                 res = True

--- a/QUANTAXIS/QAUtil/QAParameter.py
+++ b/QUANTAXIS/QAUtil/QAParameter.py
@@ -124,9 +124,9 @@ class ORDER_STATUS():
     # FAILED = 600
 
     NEW = 'new'
-    SUCCESS_ALL = 'success_all'
+    SUCCESS_ALL = 'success_all' # == FINISHED
     SUCCESS_PART = 'success_part'
-    QUEUED = 'queued'  # queued 用于表示在order_queue中 实际表达的意思是订单存活 待成交
+    QUEUED = 'queued'  # queued 用于表示在order_queue中 实际表达的意思是订单存活 待成交 == ALIVED
     CANCEL_ALL = 'cancel_all'
     CANCEL_PART = 'cancel_part'
     SETTLED = 'settled'


### PR DESCRIPTION
# 使用AccPro来承担 OMS业务, 使用POS仅仅对仓位进行精细控制

订单状态 ==> QA_Order().status

成交记录 ==> QA_AccPro.history

仓位属性: 

QA_AccPro.pms[pos_id].cur_pos

## 完善AccPro的save/update/reload 以及POSITION的reload机制

QA_AccountPro的存储库: DATABASE.accountPro

QA_Position 的存储库: DATABASE.positions

reload 机制:

QA_Position(auto_reload=True)

QAAccPro使用 reload在message字段中的position_id列来调用Position更新


## 新增Api

AccPro

positions_with_pos

multiIndex DataFrame, 第一个index是code, 第二个index是pos_id

positions
 
单index DataFrame, 是汇总的持仓表

hold_detail_with_pos

mulitindex DataFrame 第一个index是code, 第二个index是pos_id

包含了
{'volume_long': 0,
 'volume_long_his': 0,
 'volume_long_today': 0,
 'volume_short': 0,
 'volume_short_his': 0,
 'volume_short_today': 0}
