### PR TITLE
Update QASetting.py

### DIFF
--- a/QUANTAXIS/QAUtil/QASetting.py
+++ b/QUANTAXIS/QAUtil/QASetting.py
@@ -92,13 +92,24 @@ class QA_Setting():
             [type] -- [description]
         """
 
+        config = configparser.ConfigParser()
+        if os.path.exists(CONFIGFILE_PATH):
+            config.read(CONFIGFILE_PATH)
 
-        res = self.client.quantaxis.usersetting.find_one({'section': section})
-        if res:
-            return res.get(option, default_value)
+            try:
+                res = config.get(section, option)
+            except:
+                res = default_value
+
+            return res
+
         else:
-            self.set_config(section, option, default_value)
-            return default_value
+            res = self.client.quantaxis.usersetting.find_one({'section': section})
+            if res:
+                return res.get(option, default_value)
+            else:
+                self.set_config(section, option, default_value)
+                return default_value
 
     def set_config(
             self,


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/blob/master/CHANGELOG.md)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
QASetting以前不支持多个客户端连接同一个数据库，原因是log文件的位置从数据库中读取。
现在修改为首先从本地setting文件中读取，如果没有本地配置则从数据库中读取。


作者信息:winglight
时间: 2019.6.10
