### PR TITLE
update

### DIFF
--- a/QUANTAXIS/QAMarket/QAOrder.py
+++ b/QUANTAXIS/QAMarket/QAOrder.py
@@ -389,7 +389,7 @@ class QA_Order():
                         self.towards,
                         trade_time
                     )
-                    if res == 0
+                    if res == 0:
                         return self.trade_message(
                             trade_id,
                             trade_price,

--- a/QUANTAXIS/QAMarket/QAOrder.py
+++ b/QUANTAXIS/QAMarket/QAOrder.py
@@ -379,7 +379,7 @@ class QA_Order():
                     )
                     self.trade_amount += trade_amount
                     self.trade_time.append(trade_time)
-                    self.callback(
+                    res = self.callback(
                         self.code,
                         trade_id,
                         self.order_id,
@@ -389,12 +389,15 @@ class QA_Order():
                         self.towards,
                         trade_time
                     )
-                    return self.trade_message(
-                        trade_id,
-                        trade_price,
-                        trade_amount,
-                        trade_time
-                    )
+                    if res == 0
+                        return self.trade_message(
+                            trade_id,
+                            trade_price,
+                            trade_amount,
+                            trade_time
+                        )
+                    else:
+                        return False
                 else:
                     return False
         else:

--- a/QUANTAXIS/QAMarket/QAPosition.py
+++ b/QUANTAXIS/QAMarket/QAPosition.py
@@ -464,7 +464,8 @@ class QA_Position():
             self.orders[order_id] = order
             return order
         else:
-            return RuntimeError('ORDER CHECK FALSE: {}'.format(self.code))
+            print(RuntimeError('ORDER CHECK FALSE: {}'.format(self.code)))
+            return False
 
     def update_pos(self, price, amount, towards):
         """支持股票/期货的更新仓位


### PR DESCRIPTION
# QUANTAXIS PR 😇

## 1. 增加对于Account.receive_deal/receive_simpledeal的状态返回

0 ==> 成功  -1 ==> 失败

如果从外部直接调用, 可以基于这两个进行判断

如果基于QA_Order.callback的改写 ==>

QA_Order.trade 函数在Account.receive_deal失败的时候会返回False

可以基于以下逻辑块进行判断 
```python
transanction = QA_Order.trade....

if transaction:
  xxxx
```


## 2. 在Account.receive_deal中增加了对于可平数量的判断
