### PR TITLE
In QAUser.py, change self.portfolio_list from dict type to list type.

### DIFF
--- a/QUANTAXIS/QAARP/QAUser.py
+++ b/QUANTAXIS/QAARP/QAUser.py
@@ -111,7 +111,7 @@ class QA_User():
             ],
             unique=True
         )
-        self.portfolio_list = {}
+        self.portfolio_list = []
 
         # ==============================
         self.phone = phone


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
第一次运行des\securities\data_sources\quantaxis\EXAMPLE\2_类的测试与讲解\QAAccount.ipynb 如下代码报错误
import QUANTAXIS as QA
import uuid
user = QA.QA_User(username ='quantaxis', password = 'quantaxis')
portfolio=user.new_portfolio('x1')
account = portfolio.new_account(account_cookie='test')
---------------------------------------------------------------------------

AttributeError                            Traceback (most recent call last)
<ipython-input-6-91b413c0fcf5> in <module>()
      2 import uuid
      3 user = QA.QA_User(username ='quantaxis', password = 'quantaxis')
----> 4 portfolio=user.new_portfolio('x1')
      5 account = portfolio.new_account(account_cookie='test')

~\AppData\Local\Continuum\anaconda3\envs\Quant\lib\site-packages\QUANTAXIS\QAARP\QAUser.py in new_portfolio(self, portfolio_cookie)
    389 
    390         if portfolio_cookie not in self.portfolio_list:
--> 391             self.portfolio_list.append(portfolio_cookie)
    392             return QA_Portfolio(
    393                 user_cookie=self.user_cookie,

AttributeError: 'dict' object has no attribute 'append'

anaconda3\envs\Quant\lib\site-packages\QUANTAXIS\QAARP\QAUser.py
分析：
  检查代码后确认应该是list类型，因为最初是用dict，后来才改为list，但这个初始值没有同步修改。
  同时这个问题只有在第一次建立账户时才会报错。因此修改如下：
        self.portfolio_list = [] # portfolio_list is a list not a dict ,so change {} to []

作者信息: Wang Bin
时间: 2019-8-29
