### PR TITLE
添加三个命令可以对单个 stock,index,etf进行日线更新

### DIFF
--- a/QUANTAXIS/QACmd/__init__.py
+++ b/QUANTAXIS/QACmd/__init__.py
@@ -43,12 +43,15 @@ from QUANTAXIS.QASU.main import (
     QA_SU_save_stock_info,
     QA_SU_save_stock_info_tushare,
     QA_SU_save_stock_day,
+    QA_SU_save_single_stock_day,
     QA_SU_save_index_day,
+    QA_SU_save_single_index_day,
     QA_SU_save_index_min,
     QA_SU_save_future_list,
     QA_SU_save_index_list,
     QA_SU_save_etf_list,
     QA_SU_save_etf_day,
+    QA_SU_save_single_etf_day,
     QA_SU_save_etf_min,
     QA_SU_save_financialfiles,
     QA_SU_save_option_50etf_day,
@@ -228,6 +231,7 @@ class CLI(cmd.Cmd):
             命令格式: save ox: save option_contract_list/option_day/option_min/option_commodity_day/option_commodity_min \n\
             ------------------------------------------------------------ \n\
             命令格式：save stock_day  : 保存日线数据 \n\
+            命令格式：save single_stock_day  : 保存日线数据 \n\
             命令格式：save stock_xdxr : 保存日除权除息数据 \n\
             命令格式：save stock_min  : 保存分钟线数据 \n\
             命令格式：save index_day  : 保存指数日线数据 \n\
@@ -404,7 +408,12 @@ class CLI(cmd.Cmd):
                 QA_SU_save_option_50etf_min('tdx')
                 QA_SU_save_option_commodity_day('tdx')
                 QA_SU_save_option_commodity_min('tdx')
-
+            elif len(arg) == 2 and arg[0] == 'single_stock_day':
+                QA_SU_save_single_stock_day(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_index_day':
+                QA_SU_save_single_index_day(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_etf_day':
+                QA_SU_save_single_etf_day(arg[1], 'tdx')
             else:
                 for i in arg:
                     if i == 'insert_user':

--- a/QUANTAXIS/QASU/main.py
+++ b/QUANTAXIS/QASU/main.py
@@ -195,6 +195,27 @@ def QA_SU_save_stock_day(engine, client=DATABASE, paralleled=False):
     engine.QA_SU_save_stock_day(client=client)
 
 
+def QA_SU_save_single_stock_day(code, engine, client=DATABASE, paralleled=False):
+    """save stock_day
+
+    Arguments:
+        code: stock code
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+
+    :param paralleled: 是否并行处理(default: {True})
+    """
+
+    engine = select_save_engine(engine, paralleled=paralleled)
+    engine.QA_SU_save_single_stock_day(code=code, client=client)
+
+
+
+
+
+
 def QA_SU_save_option_contract_list(engine, client=DATABASE):
     '''
 
@@ -300,6 +321,24 @@ def QA_SU_save_index_day(engine, client=DATABASE, paralleled=False):
     engine = select_save_engine(engine, paralleled=paralleled)
     engine.QA_SU_save_index_day(client=client)
 
+def QA_SU_save_single_index_day(code, engine, client=DATABASE, paralleled=False):
+    """save index_day
+
+    Arguments:
+        code: index code
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+
+    :param paralleled: 是否并行处理(default: {True})
+    """
+
+    engine = select_save_engine(engine, paralleled=paralleled)
+    engine.QA_SU_save_single_index_day(code=code, client=client)
+
+
+
 
 def QA_SU_save_index_min(engine, client=DATABASE):
     """save index_min
@@ -328,6 +367,21 @@ def QA_SU_save_etf_day(engine, client=DATABASE, paralleled=False):
 
     engine = select_save_engine(engine, paralleled=paralleled)
     engine.QA_SU_save_etf_day(client=client)
+
+def QA_SU_save_single_etf_day(code, engine, client=DATABASE, paralleled=False):
+    """save etf_day
+
+    Arguments:
+        code: etf code
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    engine = select_save_engine(engine, paralleled=paralleled)
+    engine.QA_SU_save_single_etf_day(code = code, client=client)
+
 
 
 def QA_SU_save_etf_min(engine, client=DATABASE):


### PR DESCRIPTION
例如： save single_stock_day 600066, save single_index_day 000300, save single_etf_day 510050

# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:

是用户可以对单个stock, index, etf 进行日线数据的更新 

作者信息:
时间: 9/1/2019, 1:25AM, EST
