### PR TITLE
add save single_stock_min, single_index_min and single_etf_min

### DIFF
--- a/QUANTAXIS/QACmd/__init__.py
+++ b/QUANTAXIS/QACmd/__init__.py
@@ -38,6 +38,7 @@ from QUANTAXIS.QAUtil import QA_util_log_info, QA_Setting, QA_util_mongo_initial
 from QUANTAXIS.QASU.main import (
     QA_SU_save_stock_list,
     QA_SU_save_stock_min,
+    QA_SU_save_single_stock_min,
     QA_SU_save_stock_xdxr,
     QA_SU_save_stock_block,
     QA_SU_save_stock_info,
@@ -47,12 +48,14 @@ from QUANTAXIS.QASU.main import (
     QA_SU_save_index_day,
     QA_SU_save_single_index_day,
     QA_SU_save_index_min,
+    QA_SU_save_single_index_min,
     QA_SU_save_future_list,
     QA_SU_save_index_list,
     QA_SU_save_etf_list,
     QA_SU_save_etf_day,
     QA_SU_save_single_etf_day,
     QA_SU_save_etf_min,
+    QA_SU_save_single_etf_min,
     QA_SU_save_financialfiles,
     QA_SU_save_option_50etf_day,
     QA_SU_save_option_50etf_min,
@@ -231,14 +234,17 @@ class CLI(cmd.Cmd):
             命令格式: save ox: save option_contract_list/option_day/option_min/option_commodity_day/option_commodity_min \n\
             ------------------------------------------------------------ \n\
             命令格式：save stock_day  : 保存日线数据 \n\
-            命令格式：save single_stock_day  : 保存日线数据 \n\
+            命令格式：save single_stock_day  : 保存单个股票日线数据 \n\
             命令格式：save stock_xdxr : 保存日除权除息数据 \n\
             命令格式：save stock_min  : 保存分钟线数据 \n\
+            命令格式：save single_stock_min  : 保存单个股票分钟线数据 \n\
             命令格式：save index_day  : 保存指数日线数据 \n\
             命令格式：save index_min  : 保存指数分钟线数据 \n\
+            命令格式：save single_index_min  : 保存单个指数分钟线数据 \n\
             命令格式：save future_day  : 保存期货日线数据 \n\
             命令格式：save future_min  : 保存期货分钟线数据 \n\
             命令格式：save etf_day    : 保存ETF日线数据 \n\
+            命令格式：save single_etf_day    : 保存单个ETF日线数据 \n\
             命令格式：save etf_min    : 保存ET分钟数据 \n\
             命令格式：save stock_list : 保存股票列表 \n\
             命令格式：save stock_block: 保存板块 \n\
@@ -414,6 +420,12 @@ class CLI(cmd.Cmd):
                 QA_SU_save_single_index_day(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_etf_day':
                 QA_SU_save_single_etf_day(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_stock_min':
+                QA_SU_save_single_stock_min(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_index_min':
+                QA_SU_save_single_index_min(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_etf_min':
+                QA_SU_save_single_etf_min(arg[1], 'tdx')
             else:
                 for i in arg:
                     if i == 'insert_user':

--- a/QUANTAXIS/QASU/main.py
+++ b/QUANTAXIS/QASU/main.py
@@ -213,9 +213,6 @@ def QA_SU_save_single_stock_day(code, engine, client=DATABASE, paralleled=False)
 
 
 
-
-
-
 def QA_SU_save_option_contract_list(engine, client=DATABASE):
     '''
 
@@ -305,6 +302,20 @@ def QA_SU_save_stock_min(engine, client=DATABASE):
     engine.QA_SU_save_stock_min(client=client)
 
 
+def QA_SU_save_single_stock_min(code, engine, client=DATABASE):
+    """save stock_min
+
+    Arguments:
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    engine = select_save_engine(engine)
+    engine.QA_SU_save_single_stock_min(code=code, client=client)
+
+
 @print_used_time
 def QA_SU_save_index_day(engine, client=DATABASE, paralleled=False):
     """save index_day
@@ -354,6 +365,20 @@ def QA_SU_save_index_min(engine, client=DATABASE):
     engine.QA_SU_save_index_min(client=client)
 
 
+def QA_SU_save_single_index_min(code, engine, client=DATABASE):
+    """save index_min
+
+    Arguments:
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    engine = select_save_engine(engine)
+    engine.QA_SU_save_single_index_min(code=code, client=client)
+
+
 @print_used_time
 def QA_SU_save_etf_day(engine, client=DATABASE, paralleled=False):
     """save etf_day
@@ -380,7 +405,7 @@ def QA_SU_save_single_etf_day(code, engine, client=DATABASE, paralleled=False):
     """
 
     engine = select_save_engine(engine, paralleled=paralleled)
-    engine.QA_SU_save_single_etf_day(code = code, client=client)
+    engine.QA_SU_save_single_etf_day(code=code, client=client)
 
 
 
@@ -396,6 +421,21 @@ def QA_SU_save_etf_min(engine, client=DATABASE):
 
     engine = select_save_engine(engine)
     engine.QA_SU_save_etf_min(client=client)
+
+
+def QA_SU_save_single_etf_min(code, engine, client=DATABASE):
+    """save etf_min
+
+    Arguments:
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    engine = select_save_engine(engine)
+    engine.QA_SU_save_single_etf_min(code = code, client=client)
+
 
 
 def QA_SU_save_stock_xdxr(engine, client=DATABASE):

--- a/QUANTAXIS/QASU/save_tdx.py
+++ b/QUANTAXIS/QASU/save_tdx.py
@@ -768,6 +768,130 @@ def QA_SU_save_stock_min(client=DATABASE, ui_log=None, ui_progress=None):
         QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
         QA_util_log_info(err, ui_log=ui_log)
 
+def QA_SU_save_single_stock_min(code : str, client=DATABASE, ui_log=None, ui_progress=None):
+    """save single stock_min
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    #stock_list = QA_fetch_get_stock_list().code.unique().tolist()
+    stock_list = [code]
+    coll = client.stock_min
+    coll.create_index(
+        [
+            ('code',
+             pymongo.ASCENDING),
+            ('time_stamp',
+             pymongo.ASCENDING),
+            ('date_stamp',
+             pymongo.ASCENDING)
+        ]
+    )
+    err = []
+
+    def __saving_work(code, coll):
+        QA_util_log_info(
+            '##JOB03 Now Saving STOCK_MIN ==== {}'.format(str(code)),
+            ui_log=ui_log
+        )
+        try:
+            for type in ['1min', '5min', '15min', '30min', '60min']:
+                ref_ = coll.find({'code': str(code)[0:6], 'type': type})
+                end_time = str(now_time())[0:19]
+                if ref_.count() > 0:
+                    start_time = ref_[ref_.count() - 1]['datetime']
+
+                    QA_util_log_info(
+                        '##JOB03.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+                    if start_time != end_time:
+                        __data = QA_fetch_get_stock_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data)[1::]
+                            )
+                else:
+                    start_time = '2015-01-01'
+                    QA_util_log_info(
+                        '##JOB03.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+                    if start_time != end_time:
+                        __data = QA_fetch_get_stock_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data)
+                            )
+        except Exception as e:
+            QA_util_log_info(e, ui_log=ui_log)
+            err.append(code)
+            QA_util_log_info(err, ui_log=ui_log)
+
+    executor = ThreadPoolExecutor(max_workers=4)
+    # executor.map((__saving_work,  stock_list[i_], coll),URLS)
+    res = {
+        executor.submit(__saving_work,
+                        stock_list[i_],
+                        coll)
+        for i_ in range(len(stock_list))
+    }
+    count = 1
+    for i_ in concurrent.futures.as_completed(res):
+        QA_util_log_info(
+            'The {} of Total {}'.format(count,
+                                        len(stock_list)),
+            ui_log=ui_log
+        )
+
+        strProgress = 'DOWNLOAD PROGRESS {} '.format(
+            str(float(count / len(stock_list) * 100))[0:4] + '%'
+        )
+        intProgress = int(count / len(stock_list) * 10000.0)
+        QA_util_log_info(
+            strProgress,
+            ui_log,
+            ui_progress=ui_progress,
+            ui_progress_int_value=intProgress
+        )
+        count = count + 1
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS', ui_log=ui_log)
+    else:
+        QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
+        QA_util_log_info(err, ui_log=ui_log)
+
 def QA_SU_save_single_index_day(code : str, client=DATABASE, ui_log=None):
     """save index_day
 
@@ -1098,6 +1222,132 @@ def QA_SU_save_index_min(client=DATABASE, ui_log=None, ui_progress=None):
         QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
         QA_util_log_info(err, ui_log=ui_log)
 
+def QA_SU_save_single_index_min(code : str, client=DATABASE, ui_log=None, ui_progress=None):
+    """save single index_min
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    #__index_list = QA_fetch_get_stock_list('index')
+    __index_list = [code]
+    coll = client.index_min
+    coll.create_index(
+        [
+            ('code',
+             pymongo.ASCENDING),
+            ('time_stamp',
+             pymongo.ASCENDING),
+            ('date_stamp',
+             pymongo.ASCENDING)
+        ]
+    )
+    err = []
+
+    def __saving_work(code, coll):
+
+        QA_util_log_info(
+            '##JOB05 Now Saving Index_MIN ==== {}'.format(str(code)),
+            ui_log=ui_log
+        )
+        try:
+
+            for type in ['1min', '5min', '15min', '30min', '60min']:
+                ref_ = coll.find({'code': str(code)[0:6], 'type': type})
+                end_time = str(now_time())[0:19]
+                if ref_.count() > 0:
+                    start_time = ref_[ref_.count() - 1]['datetime']
+
+                    QA_util_log_info(
+                        '##JOB05.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_index_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data[1::])
+                            )
+                else:
+                    start_time = '2015-01-01'
+
+                    QA_util_log_info(
+                        '##JOB05.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_index_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data)
+                            )
+        except:
+            err.append(code)
+
+    executor = ThreadPoolExecutor(max_workers=4)
+
+    res = {
+        executor.submit(__saving_work,
+                        __index_list[i_],
+                        coll)
+        for i_ in range(len(__index_list))
+    }  # multi index ./.
+    count = 1
+    for i_ in concurrent.futures.as_completed(res):
+        strLogProgress = 'DOWNLOAD PROGRESS {} '.format(
+            str(float(count / len(__index_list) * 100))[0:4] + '%'
+        )
+        intLogProgress = int(float(count / len(__index_list) * 10000.0))
+        QA_util_log_info(
+            'The {} of Total {}'.format(count,
+                                        len(__index_list)),
+            ui_log=ui_log
+        )
+        QA_util_log_info(
+            strLogProgress,
+            ui_log=ui_log,
+            ui_progress=ui_progress,
+            ui_progress_int_value=intLogProgress
+        )
+        count = count + 1
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS', ui_log=ui_log)
+    else:
+        QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
+        QA_util_log_info(err, ui_log=ui_log)
+
 
 def QA_SU_save_single_etf_day(code : str, client=DATABASE, ui_log=None):
     """save etf_day
@@ -1369,7 +1619,134 @@ def QA_SU_save_etf_min(client=DATABASE, ui_log=None, ui_progress=None):
                         coll)
         for i_ in range(len(__index_list))
     }  # multi index ./.
-    count = 0
+    count = 1
+    for i_ in concurrent.futures.as_completed(res):
+        QA_util_log_info(
+            'The {} of Total {}'.format(count,
+                                        len(__index_list)),
+            ui_log=ui_log
+        )
+        strLogProgress = 'DOWNLOAD PROGRESS {} '.format(
+            str(float(count / len(__index_list) * 100))[0:4] + '%'
+        )
+        intLogProgress = int(float(count / len(__index_list) * 10000.0))
+
+        QA_util_log_info(
+            strLogProgress,
+            ui_log=ui_log,
+            ui_progress=ui_progress,
+            ui_progress_int_value=intLogProgress
+        )
+        count = count + 1
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS', ui_log=ui_log)
+    else:
+        QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
+        QA_util_log_info(err, ui_log=ui_log)
+
+def QA_SU_save_single_etf_min(code : str, client=DATABASE, ui_log=None, ui_progress=None):
+    """save single etf_min
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    #__index_list = QA_fetch_get_stock_list('etf')
+    __index_list = [code]
+    coll = client.index_min
+    coll.create_index(
+        [
+            ('code',
+             pymongo.ASCENDING),
+            ('time_stamp',
+             pymongo.ASCENDING),
+            ('date_stamp',
+             pymongo.ASCENDING)
+        ]
+    )
+    err = []
+
+    def __saving_work(code, coll):
+
+        QA_util_log_info(
+            '##JOB07 Now Saving ETF_MIN ==== {}'.format(str(code)),
+            ui_log=ui_log
+        )
+        try:
+
+            for type in ['1min', '5min', '15min', '30min', '60min']:
+                ref_ = coll.find({'code': str(code)[0:6], 'type': type})
+                end_time = str(now_time())[0:19]
+                if ref_.count() > 0:
+                    start_time = ref_[ref_.count() - 1]['datetime']
+
+                    QA_util_log_info(
+                        '##JOB07.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_index_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data[1::])
+                            )
+                else:
+                    start_time = '2015-01-01'
+
+                    QA_util_log_info(
+                        '##JOB07.{} Now Saving {} from {} to {} =={} '.format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_index_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data)
+                            )
+        except:
+            err.append(code)
+
+    executor = ThreadPoolExecutor(max_workers=4)
+
+    res = {
+        executor.submit(__saving_work,
+                        __index_list[i_],
+                        coll)
+        for i_ in range(len(__index_list))
+    }  # multi index ./.
+    count = 1
     for i_ in concurrent.futures.as_completed(res):
         QA_util_log_info(
             'The {} of Total {}'.format(count,


### PR DESCRIPTION
增加三个方法可以保存stock, index, etf的min 数据
save single_stock_min 600066
save single_index_min 000300
save single_etf_min 510050

# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

qa的 yapf格式也是从vnpy那拿来的 参见 https://github.com/vnpy/vnpy/blob/v2.0-DEV/.style.yapf

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:

增加三个方法可以保存stock, index, etf的min 数据
save single_stock_min 600066
save single_index_min 000300
save single_etf_min 510050

作者信息:
时间: 9/6/2019
