### PR TITLE
优化 QAAccountPro 的下单模式

### DIFF
--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -152,6 +152,14 @@ class QA_AccountPRO(QA_Worker):
         ) if isinstance(init_hold,
                         dict) else init_hold
         self.init_hold.index.name = 'code'
+        self.positions = {}
+        if len(self.init_hold) > 0:
+            for code in init_hold:
+                self.positions[code] = QA_Position(code=code, user_cookie=self.user_cookie,
+                                                   volume_long_his=init_hold[code],
+                                                   portfolio_cookie=self.portfolio_cookie,
+                                                   account_cookie=self.account_cookie,
+                                                   auto_reload=False)
         self.cash = [self.init_cash]
         self.cash_available = self.cash[-1]  # 可用资金
         self.sell_available = copy.deepcopy(self.init_hold)
@@ -170,7 +178,6 @@ class QA_AccountPRO(QA_Worker):
         }                        # 日结算
         self.today_trade = {'last': [], 'current': []}
         self.today_orders = {'last': [], 'current': []}
-        self.positions = {}
 
         ########################################################################
         # 规则类
@@ -226,8 +233,8 @@ class QA_AccountPRO(QA_Worker):
         """
 
         pos = self.positions.get(code, QA_Position(code=code, user_cookie=self.user_cookie,
-                                                   portfolio_cookie=self.portfolio_cookie, 
-                                                   account_cookie=self.account_cookie, 
+                                                   portfolio_cookie=self.portfolio_cookie,
+                                                   account_cookie=self.account_cookie,
                                                    auto_reload=False))
         if pos.market_type == self.market_type:
             self.positions[code] = pos
@@ -239,7 +246,6 @@ class QA_AccountPRO(QA_Worker):
     @property
     def hold_available(self):
         pass
-
 
     @property
     def message(self):
@@ -424,8 +430,8 @@ class QA_AccountPRO(QA_Worker):
             return QA_util_get_trade_range(self.start_date, self.end_date)
         else:
 
-            return QA_util_get_trade_range(str(min(self.time_index_max))[0:10], 
-                                           str(max(str(max(self.time_index_max)),self.end_date))[0:10])
+            return QA_util_get_trade_range(str(min(self.time_index_max))[0:10],
+                                           str(max(str(max(self.time_index_max)), self.end_date))[0:10])
 
     @property
     def total_commission(self):
@@ -501,11 +507,12 @@ class QA_AccountPRO(QA_Worker):
 #        res_['date']=[ i[0:10]  for i in res_['datetime']]
 #        res_=res_[res_['date'].isin(self.trade_range)]
 
+
     @property
     def trade_day(self):
         return list(
             pd.Series(self.time_index_max
-                     ).apply(lambda x: str(x)[0:10]).unique()
+                      ).apply(lambda x: str(x)[0:10]).unique()
         )
 
     @property
@@ -653,7 +660,7 @@ class QA_AccountPRO(QA_Worker):
                 pd.Series(
                     data=None,
                     index=pd.to_datetime(self.trade_range_max
-                                        ).set_names('date'),
+                                         ).set_names('date'),
                     name='predrop'
                 )
             )
@@ -702,11 +709,11 @@ class QA_AccountPRO(QA_Worker):
             hold_available = self.history_table.set_index(
                 'datetime'
             ).sort_index().loc[:datetime].groupby('code'
-                                                 ).amount.sum().sort_index()
+                                                  ).amount.sum().sort_index()
 
         return pd.concat([self.init_hold,
                           hold_available]).groupby('code').sum().sort_index(
-                          ).apply(lambda x: x if x > 0 else None).dropna()
+        ).apply(lambda x: x if x > 0 else None).dropna()
 
     def current_hold_price(self):
         """计算目前持仓的成本  用于模拟盘和实盘查询
@@ -768,7 +775,7 @@ class QA_AccountPRO(QA_Worker):
                 'datetime',
                 drop=False
             ).sort_index().loc[:datetime].groupby('code').apply(weights
-                                                               ).dropna()
+                                                                ).dropna()
 
     # @property
     def hold_time(self, datetime=None):
@@ -781,7 +788,7 @@ class QA_AccountPRO(QA_Worker):
         def weights(x):
             if sum(x['amount']) != 0:
                 return pd.Timestamp(self.datetime
-                                   ) - pd.to_datetime(x.datetime.max())
+                                    ) - pd.to_datetime(x.datetime.max())
             else:
                 return np.nan
 
@@ -795,7 +802,7 @@ class QA_AccountPRO(QA_Worker):
                 'datetime',
                 drop=False
             ).sort_index().loc[:datetime].groupby('code').apply(weights
-                                                               ).dropna()
+                                                                ).dropna()
 
     def reset_assets(self, init_cash=None):
         'reset_history/cash/'
@@ -803,7 +810,7 @@ class QA_AccountPRO(QA_Worker):
         self.history = []
         self.init_cash = init_cash
         self.cash = [self.init_cash]
-        self.cash_available = self.cash[-1] # 在途资金
+        self.cash_available = self.cash[-1]  # 在途资金
 
     @property
     def close_positions_order(self):
@@ -852,7 +859,6 @@ class QA_AccountPRO(QA_Worker):
                     self.running_environment
                 )
             )
-
 
     def send_order(
             self,
@@ -1112,9 +1118,11 @@ class QA_AccountPRO(QA_Worker):
         market_towards = 1 if trade_towards > 0 else -1
         # value 合约价值 unit 合约乘数
         if self.allow_margin:
-            frozen = self.market_preset.get_frozen(code)                  # 保证金率
-            unit = self.market_preset.get_unit(code)                      # 合约乘数
-            raw_trade_money = trade_price * trade_amount * market_towards # 总市值
+            frozen = self.market_preset.get_frozen(
+                code)                  # 保证金率
+            unit = self.market_preset.get_unit(
+                code)                      # 合约乘数
+            raw_trade_money = trade_price * trade_amount * market_towards  # 总市值
             value = raw_trade_money * unit                                # 合约总价值
             trade_money = value * frozen                                  # 交易保证金
         else:
@@ -1123,8 +1131,8 @@ class QA_AccountPRO(QA_Worker):
             value = trade_money
             unit = 1
             frozen = 1
-                                                                          # 计算费用
-                                                                          # trade_price
+            # 计算费用
+            # trade_price
 
         if self.market_type == MARKET_TYPE.FUTURE_CN:
             # 期货不收税
@@ -1144,7 +1152,7 @@ class QA_AccountPRO(QA_Worker):
                     commission_fee_preset['commission_coeff_today_peramount'] * \
                     abs(value)
 
-            tax_fee = 0 # 买入不收印花税
+            tax_fee = 0  # 买入不收印花税
         elif self.market_type == MARKET_TYPE.STOCK_CN:
 
             commission_fee = self.commission_coeff * \
@@ -1152,7 +1160,7 @@ class QA_AccountPRO(QA_Worker):
 
             commission_fee = 5 if commission_fee < 5 else commission_fee
             if int(trade_towards) > 0:
-                tax_fee = 0 # 买入不收印花税
+                tax_fee = 0  # 买入不收印花税
             else:
                 tax_fee = self.tax_coeff * abs(trade_money)
 
@@ -1225,7 +1233,7 @@ class QA_AccountPRO(QA_Worker):
                         trade_amount
                     )
                     self.frozen[code][str(trade_towards)
-                                     ]['amount'] += trade_amount
+                                      ]['amount'] += trade_amount
 
                     self.cash.append(
                         self.cash[-1] - abs(trade_money) - commission_fee -
@@ -1245,7 +1253,7 @@ class QA_AccountPRO(QA_Worker):
                                          ORDER_DIRECTION.BUY_CLOSETODAY]:
                         # self.frozen[code][ORDER_DIRECTION.SELL_OPEN]['money'] -= trade_money
                         self.frozen[code][str(ORDER_DIRECTION.SELL_OPEN
-                                             )]['amount'] -= trade_amount
+                                              )]['amount'] -= trade_amount
 
                         frozen_part = self.frozen[code][str(
                             ORDER_DIRECTION.SELL_OPEN
@@ -1286,16 +1294,16 @@ class QA_AccountPRO(QA_Worker):
                         if self.frozen[code][str(
                                 ORDER_DIRECTION.SELL_OPEN)]['amount'] == 0:
                             self.frozen[code][str(ORDER_DIRECTION.SELL_OPEN
-                                                 )]['money'] = 0
+                                                  )]['money'] = 0
                             self.frozen[code][str(ORDER_DIRECTION.SELL_OPEN
-                                                 )]['avg_price'] = 0
+                                                  )]['avg_price'] = 0
 
                     # 卖出平仓  之前是多开
                     elif trade_towards in [ORDER_DIRECTION.SELL_CLOSE,
                                            ORDER_DIRECTION.SELL_CLOSETODAY]:
                         # self.frozen[code][ORDER_DIRECTION.BUY_OPEN]['money'] -= trade_money
                         self.frozen[code][str(ORDER_DIRECTION.BUY_OPEN
-                                             )]['amount'] -= trade_amount
+                                              )]['amount'] -= trade_amount
 
                         frozen_part = self.frozen[code][str(
                             ORDER_DIRECTION.BUY_OPEN
@@ -1308,10 +1316,10 @@ class QA_AccountPRO(QA_Worker):
                         if self.frozen[code][str(
                                 ORDER_DIRECTION.BUY_OPEN)]['amount'] == 0:
                             self.frozen[code][str(ORDER_DIRECTION.BUY_OPEN
-                                                 )]['money'] = 0
+                                                  )]['money'] = 0
                             self.frozen[code][str(ORDER_DIRECTION.BUY_OPEN
-                                                 )]['avg_price'] = 0
-            else: # 不允许卖空开仓的==> 股票
+                                                  )]['avg_price'] = 0
+            else:  # 不允许卖空开仓的==> 股票
 
                 self.cash.append(
                     self.cash[-1] - trade_money - tax_fee - commission_fee
@@ -1330,7 +1338,8 @@ class QA_AccountPRO(QA_Worker):
             ] else 0
 
             try:
-                total_frozen = sum([itex.get('avg_price',0)* itex.get('amount',0) for item in self.frozen.values() for itex in item.values()])
+                total_frozen = sum([itex.get('avg_price', 0) * itex.get('amount', 0)
+                                    for item in self.frozen.values() for itex in item.values()])
             except Exception as e:
                 print(e)
                 total_frozen = 0
@@ -1516,6 +1525,7 @@ class QA_AccountPRO(QA_Worker):
         self.margin = message['accounts']['margin']
 
         self.commission = message['accounts']['commission']
+
     def save(self):
         """
         存储账户信息
@@ -1550,7 +1560,7 @@ class QA_AccountPRO(QA_Worker):
         self.sell_available = copy.deepcopy(self.init_hold)
         self.history = []
         self.cash = [self.init_cash]
-        self.cash_available = self.cash[-1] # 在途资金
+        self.cash_available = self.cash[-1]  # 在途资金
 
     def change_cash(self, money):
         """
@@ -1582,4 +1592,3 @@ class QA_AccountPRO(QA_Worker):
             drop=False
         ).loc[slice(pd.Timestamp(start),
                     pd.Timestamp(end))]
-

--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -216,6 +216,8 @@ class QA_AccountPRO(QA_Worker):
         if auto_reload:
             self.reload()
 
+        print(self.positions)    
+
     def __repr__(self):
         return '< QA_AccountPRO {} market: {}>'.format(
             self.account_cookie,
@@ -1533,7 +1535,7 @@ class QA_AccountPRO(QA_Worker):
         save_account(self.message)
 
     def reload(self):
-
+        print('QAACCPRO: reload from DATABASE')
         message = self.client.find_one(
             {
                 'account_cookie': self.account_cookie,

--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -154,7 +154,7 @@ class QA_AccountPRO(QA_Worker):
         self.init_hold.index.name = 'code'
         self.positions = {}
         if len(self.init_hold) > 0:
-            for code in init_hold:
+            for code in init_hold.keys():
                 self.positions[code] = QA_Position(code=code, user_cookie=self.user_cookie,
                                                    volume_long_his=init_hold[code],
                                                    portfolio_cookie=self.portfolio_cookie,

--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -216,7 +216,7 @@ class QA_AccountPRO(QA_Worker):
         if auto_reload:
             self.reload()
 
-        print(self.positions)    
+        print(self.positions)
 
     def __repr__(self):
         return '< QA_AccountPRO {} market: {}>'.format(
@@ -508,7 +508,6 @@ class QA_AccountPRO(QA_Worker):
 #        res_.columns=(['datetime'])
 #        res_['date']=[ i[0:10]  for i in res_['datetime']]
 #        res_=res_[res_['date'].isin(self.trade_range)]
-
 
     @property
     def trade_day(self):
@@ -902,6 +901,8 @@ class QA_AccountPRO(QA_Worker):
             money = amount * price * self.market_preset.get_unit(code)*self.market_preset.get_frozen(code) * \
                 (1+self.commission_coeff) if amount_model is AMOUNT_MODEL.BY_AMOUNT else money
         else:
+            print(amount)
+            print(price)
             money = amount * price * \
                 (1+self.commission_coeff) if amount_model is AMOUNT_MODEL.BY_AMOUNT else money
 
@@ -1006,7 +1007,7 @@ class QA_AccountPRO(QA_Worker):
                 date=date,
                 datetime=time,
                 sending_time=time,
-                # callback=self.receive_deal,
+                callback=self.receive_deal,
                 amount=amount,
                 price=price,
                 order_model=order_model,
@@ -1045,14 +1046,14 @@ class QA_AccountPRO(QA_Worker):
 
     def receive_deal(self,
                      code,
+                     trade_id: str,
+                     order_id: str,
+                     realorder_id: str,
                      trade_price,
                      trade_amount,
                      trade_towards,
                      trade_time,
-                     message=None,
-                     order_id=None,
-                     trade_id=None,
-                     realorder_id=None):
+                     message=None):
         # if order_id in self.orders.keys():
 
         #     # update order
@@ -1088,16 +1089,16 @@ class QA_AccountPRO(QA_Worker):
         #     self.event_id += 1
         #     trade_id = str(uuid.uuid4()) if trade_id is None else trade_id
 
-        self.receive_simpledeal(
+        return self.receive_simpledeal(
             code,
             trade_price,
             trade_amount,
             trade_towards,
             trade_time,
-            message=None,
-            order_id=None,
-            trade_id=None,
-            realorder_id=None)
+            message=message,
+            order_id=order_id,
+            trade_id=trade_id,
+            realorder_id=realorder_id)
 
     def receive_simpledeal(self,
                            code,
@@ -1116,7 +1117,6 @@ class QA_AccountPRO(QA_Worker):
             pass
         else:
             self.finishedOrderid.append(realorder_id)
-
         market_towards = 1 if trade_towards > 0 else -1
         # value 合约价值 unit 合约乘数
         if self.allow_margin:
@@ -1435,6 +1435,8 @@ class QA_AccountPRO(QA_Worker):
         self.datetime = '{} 09:30:00'.format(
             QA_util_get_next_day(self.date)
         ) if self.date is not None else None
+        for item in self.positions.values():
+            item.settle()
 
     def from_message(self, message):
         """resume the account from standard message

--- a/QUANTAXIS/QAARP/QAPortfolio.py
+++ b/QUANTAXIS/QAARP/QAPortfolio.py
@@ -245,6 +245,7 @@ class QA_Portfolio(QA_Account):
             account_cookie=None,
             init_cash=1000000,
             market_type=MARKET_TYPE.STOCK_CN,
+            auto_reload=True,
             *args,
             **kwargs
     ):
@@ -271,6 +272,7 @@ class QA_Portfolio(QA_Account):
                     portfolio_cookie=self.portfolio_cookie,
                     init_cash=init_cash,
                     market_type=market_type,
+                    auto_reload=auto_reload,
                     *args,
                     **kwargs
                 )
@@ -293,6 +295,7 @@ class QA_Portfolio(QA_Account):
                         init_cash=init_cash,
                         market_type=market_type,
                         account_cookie=account_cookie,
+                        auto_reload=auto_reload,
                         *args,
                         **kwargs
                     )
@@ -307,7 +310,9 @@ class QA_Portfolio(QA_Account):
                         portfolio_cookie=self.portfolio_cookie,
                         init_cash=init_cash,
                         market_type=market_type,
-                        auto_reload=True
+                        auto_reload=auto_reload,
+                        *args,
+                        **kwargs
                     )
 
     def new_account(
@@ -315,6 +320,7 @@ class QA_Portfolio(QA_Account):
             account_cookie=None,
             init_cash=1000000,
             market_type=MARKET_TYPE.STOCK_CN,
+            auto_reload=True,
             *args,
             **kwargs
     ):
@@ -341,6 +347,7 @@ class QA_Portfolio(QA_Account):
                     portfolio_cookie=self.portfolio_cookie,
                     init_cash=init_cash,
                     market_type=market_type,
+                    auto_reload=auto_reload,
                     *args,
                     **kwargs
                 )
@@ -363,6 +370,7 @@ class QA_Portfolio(QA_Account):
                         init_cash=init_cash,
                         market_type=market_type,
                         account_cookie=account_cookie,
+                        auto_reload=auto_reload,
                         *args,
                         **kwargs
                     )
@@ -371,7 +379,7 @@ class QA_Portfolio(QA_Account):
                     self.cash.append(self.cash_available - init_cash)
                     return acc
                 else:
-                    return self.get_account_by_cookie(account_cookie)
+                    return self.get_account_by_cookie(account_cookie, auto_reload=auto_reload)
 
     def create_stockaccount(self, account_cookie, init_cash, init_hold):
         return self.new_account(account_cookie=account_cookie, init_cash=init_cash, init_hold=init_hold,
@@ -381,7 +389,7 @@ class QA_Portfolio(QA_Account):
         return self.new_account(account_cookie=account_cookie, init_cash=init_cash, init_hold=init_hold,
                                 market_type=MARKET_TYPE.FUTURE_CN, allow_t0=False,)
 
-    def get_account_by_cookie(self, cookie):
+    def get_account_by_cookie(self, cookie, auto_reload=True):
         '''
         'give the account_cookie and return the account/strategy back'
         :param cookie:
@@ -393,7 +401,7 @@ class QA_Portfolio(QA_Account):
                 account_cookie=cookie,
                 user_cookie=self.user_cookie,
                 portfolio_cookie=self.portfolio_cookie,
-                auto_reload=True
+                auto_reload=auto_reload
             )
         except:
             QA_util_log_info('Can not find this account')

--- a/QUANTAXIS/QAFetch/Fetcher.py
+++ b/QUANTAXIS/QAFetch/Fetcher.py
@@ -54,7 +54,7 @@ from QUANTAXIS.QAUtil.QASql import QA_util_sql_mongo_setting
 
 
 class QA_Fetcher():
-    def __init__(self, uri='mongodb://192.168.4.248:27017/quantaxis', username='', password=''):
+    def __init__(self, uri='mongodb://127.0.0.1:27017/quantaxis', username='', password=''):
         """
         初始化的时候 会初始化
         """

--- a/QUANTAXIS/QAMarket/QAPosition.py
+++ b/QUANTAXIS/QAMarket/QAPosition.py
@@ -516,6 +516,7 @@ class QA_Position():
         if towards == ORDER_DIRECTION.BUY:
             # 股票模式/ 期货买入开仓
             marginValue = temp_cost 
+            
             self.margin_long += marginValue
             # 重算开仓均价
             self.open_price_long = (
@@ -534,13 +535,14 @@ class QA_Position():
             #
             self.open_cost_long += temp_cost
             self.position_cost_long += temp_cost
+            self.moneypresetLeft -= marginValue
 
 
 
         elif towards == ORDER_DIRECTION.SELL:
             # 股票卖出模式:
             # 今日买入仓位不能卖出
-            if self.volume_long_his > amount:
+            if self.volume_long_his >= amount:
                 
                 self.position_cost_long = self.position_cost_long * \
                     (self.volume_long - amount)/self.volume_long
@@ -549,8 +551,9 @@ class QA_Position():
 
                 self.volume_long_his -= amount
 
-                self.volume_long_frozen_today -= amount
+                #self.volume_long_frozen_today -= amount
                 marginValue = -1*(self.position_price_long * amount)
+                self.margin_long += marginValue
                 profit = (price - self.position_price_long) * amount 
                 self.moneypresetLeft += (-marginValue + profit)
             else:

--- a/QUANTAXIS/__init__.py
+++ b/QUANTAXIS/__init__.py
@@ -31,7 +31,7 @@ by yutiansut
 2017/4/8
 """
 
-__version__ = '1.6.10'
+__version__ = '1.6.11'
 __author__ = 'yutiansut'
 
 import argparse


### PR DESCRIPTION
1. QAAccountPro的 init_hold 现在可以正确的被加载了

2. QAPortfolio在创建 QAAccountPro/ QAAccount的时候的参数可以被正确传递了

3. QAPortfolio在创建 QAAccountPro/QAccount的时候可以用auto_reload =False 来阻止使用数据库文件恢复账户了

4. QAAccountPro 的sendorder函数的callback现在正确了

5. QAAccountPro的 receive_deal函数现在QAAccount一致了

6. QAPosition的update_pos中的 SELL/BUY 模式现在可以正确更新了

7. update to 1.6.11