### PR TITLE
fix bug

### DIFF
--- a/QUANTAXIS/QAIndicator/indicators.py
+++ b/QUANTAXIS/QAIndicator/indicators.py
@@ -252,7 +252,8 @@ def QA_indicator_CCI(DataFrame, N=14):
     CCI:(TYP-MA(TYP,N))/(0.015*AVEDEV(TYP,N));
     """
     typ = (DataFrame['high'] + DataFrame['low'] + DataFrame['close']) / 3
-    cci = ((typ - MA(typ, N)) / (0.015 * AVEDEV(typ, N)))
+    ## 此处AVEDEV可能为0值  因此导致出错 +0.0000000000001
+    cci = ((typ - MA(typ, N)) / (0.015 * AVEDEV(typ, N) + 0.00000001))
     a = 100
     b = -100
 

--- a/QUANTAXIS/__init__.py
+++ b/QUANTAXIS/__init__.py
@@ -31,7 +31,7 @@ by yutiansut
 2017/4/8
 """
 
-__version__ = '1.8.4'
+__version__ = '1.8.5'
 __author__ = 'yutiansut'
 
 import argparse

--- a/QUANTAXIS/__init__.py
+++ b/QUANTAXIS/__init__.py
@@ -31,7 +31,7 @@ by yutiansut
 2017/4/8
 """
 
-__version__ = '1.8.5'
+__version__ = '1.8.6'
 __author__ = 'yutiansut'
 
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     ],
     install_requires=['pandas<=0.24.2', 'pypandoc', 'numpy>=1.12.0', 'tushare', 'flask_socketio>=2.9.0 ', 'motor>=1.1', 'seaborn>=0.8.1', 'pyconvert>=0.6.3',
                       'lxml>=4.0', ' beautifulsoup4', 'matplotlib', 'requests', 'tornado', 'janus', 'pyecharts_snapshot', 'async_timeout',
-                      'demjson>=2.2.4', 'pymongo>=3.7', 'six>=1.10.0', 'tabulate>=0.7.7', 'pytdx>=1.67', 'retrying>=1.3.3', 'Ipython', 'scipy<=1.1.0'
+                      'demjson>=2.2.4', 'pymongo>=3.7', 'six>=1.10.0', 'tabulate>=0.7.7', 'pytdx>=1.67', 'retrying>=1.3.3', 'Ipython', 'scipy<=1.1.0',
                       'zenlog>=1.1', 'delegator.py>=0.0.12', 'flask>=0.12.2', 'pyecharts>=0.5.11', 'protobuf>=3.4.0', 'fastcache', 'statsmodels<=0.9.0', 'jqdatasdk'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
1.8.5 修复的是依赖项的bug
1.8.6 修复了CCI的一个计算bug

在@般若中 的电脑上发现一个cci计算的bug已经修复 (主要是在行情无变动的时候  AVEDEV变成0 导致分母为0的情况) 感谢@般若中 同学   pip install quantaxis==1.8.6即可