### PR TITLE
对QAAnalyze_block的性能改进

### DIFF
--- a/QUANTAXIS/QAAnalysis/QAAnalysis_block.py
+++ b/QUANTAXIS/QAAnalysis/QAAnalysis_block.py
@@ -48,7 +48,7 @@ class QAAnalysis_block():
     @property
     @lru_cache()
     def market_value(self):
-        return self.market_data.add_func(QA_data_marketvalue)
+        return QA_data_marketvalue(self.market_data.data)
 
     @property
     def week_data(self):

--- a/QUANTAXIS/QAData/data_marketvalue.py
+++ b/QUANTAXIS/QAData/data_marketvalue.py
@@ -35,32 +35,30 @@ def QA_data_calc_marketvalue(data, xdxr):
                                        ['shares_after',
                                         'liquidity_after']].dropna()
     res = pd.concat([data, mv], axis=1)
-
     res = res.assign(
-        shares=res.shares_after.fillna(method='ffill'),
-        lshares=res.liquidity_after.fillna(method='ffill')
+        shares=res.shares_after.groupby(level=1).fillna(method='ffill'),
+        lshares=res.liquidity_after.groupby(level=1).fillna(method='ffill')
     )
-    return res.assign(mv=res.close*res.shares*10000, liquidity_mv=res.close*res.lshares*10000).drop(['shares_after', 'liquidity_after'], axis=1)\
-            .loc[(slice(data.index.remove_unused_levels().levels[0][0],data.index.remove_unused_levels().levels[0][-1]),slice(None)),:]
-
+    return res.assign(mv=res.close*res.shares*10000, liquidity_mv=res.close*res.lshares*10000)\
+              .drop(['shares_after', 'liquidity_after'], axis=1)\
+              .loc[(slice(data.index.remove_unused_levels().levels[0][0],data.index.remove_unused_levels().levels[0][-1]),slice(None)),:]
 
 def QA_data_marketvalue(data):
 
     def __QA_fetch_stock_xdxr(
-            code,
+            code_list,
             format_='pd',
             collections=DATABASE.stock_xdxr
     ):
         '获取股票除权信息/数据库'
         try:
             data = pd.DataFrame(
-                [item for item in collections.find({'code': code})]
-            ).drop(['_id'],
-                   axis=1)
+                [item for item in collections.find({'code': {"$in": code_list}
+                                                   },{"_id": 0})])
             data['date'] = pd.to_datetime(data['date'])
 
             return data.drop_duplicates(
-                'date',
+                ['date', 'code'],
                 keep='last'
             ).set_index(['date',
                          'code'],
@@ -86,10 +84,6 @@ def QA_data_marketvalue(data):
                     'suogu',
                     'xingquanjia'
                 ]
-            )
-
-    code = data.index.remove_unused_levels().levels[1][0] if isinstance(
-        data.index,
-        pd.core.indexes.multi.MultiIndex
-    ) else data['code'][0]
-    return QA_data_calc_marketvalue(data, __QA_fetch_stock_xdxr(code))
+            )   
+    code_list = data.index.remove_unused_levels().levels[1].tolist()
+    return QA_data_calc_marketvalue_new(data, __QA_fetch_stock_xdxr(code_list))

--- a/QUANTAXIS/QAData/data_marketvalue.py
+++ b/QUANTAXIS/QAData/data_marketvalue.py
@@ -86,4 +86,4 @@ def QA_data_marketvalue(data):
                 ]
             )   
     code_list = data.index.remove_unused_levels().levels[1].tolist()
-    return QA_data_calc_marketvalue_new(data, __QA_fetch_stock_xdxr(code_list))
+    return QA_data_calc_marketvalue(data, __QA_fetch_stock_xdxr(code_list))


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:

原始的QAAnalyze_block是通过code列表的Group对象向QUANTAXIS的数据库发送读请求，多次读写数据库造成了时间效率随code列表长度线性增长
经过改良，将n次的数据库读写改为1次，并在pandas里对股票价格数据和权息数据进行合并，显著提高了时间效率

作者信息: ChiangHao
时间: 2020-02-23
