### PR TITLE
add single future day/min save & fix min_to_day resample

### DIFF
--- a/QUANTAXIS/QACmd/__init__.py
+++ b/QUANTAXIS/QACmd/__init__.py
@@ -36,51 +36,53 @@ from QUANTAXIS.QACmd.runner import run_backtest, run
 from QUANTAXIS.QAApplication.QAAnalysis import QA_backtest_analysis_backtest
 from QUANTAXIS.QAUtil import QA_util_log_info, QA_Setting, QA_util_mongo_initial
 from QUANTAXIS.QASU.main import (
-    QA_SU_save_stock_list,
-    QA_SU_save_stock_min,
-    QA_SU_save_stock_transaction,
-    QA_SU_save_index_transaction,
-    QA_SU_save_single_stock_min,
-    QA_SU_save_stock_xdxr,
-    QA_SU_save_stock_block,
-    QA_SU_save_stock_info,
-    QA_SU_save_stock_info_tushare,
-    QA_SU_save_stock_day,
-    QA_SU_save_single_stock_day,
-    QA_SU_save_index_day,
-    QA_SU_save_single_index_day,
-    QA_SU_save_index_min,
-    QA_SU_save_single_index_min,
-    QA_SU_save_future_list,
-    QA_SU_save_index_list,
-    QA_SU_save_etf_list,
+    QA_SU_save_bond_day,
+    QA_SU_save_bond_list,
+    QA_SU_save_bond_min,
     QA_SU_save_etf_day,
-    QA_SU_save_single_etf_day,
+    QA_SU_save_etf_list,
     QA_SU_save_etf_min,
-    QA_SU_save_single_etf_min,
     QA_SU_save_financialfiles,
-    QA_SU_save_option_50etf_day,
-    QA_SU_save_option_50etf_min,
+    QA_SU_save_future_day_all,
+    QA_SU_save_future_day,
+    QA_SU_save_future_list,
+    QA_SU_save_future_min_all,
+    QA_SU_save_future_min,
+    QA_SU_save_index_day,
+    QA_SU_save_index_list,
+    QA_SU_save_index_min,
+    QA_SU_save_index_transaction,
     QA_SU_save_option_300etf_day,
     QA_SU_save_option_300etf_min,
+    QA_SU_save_option_50etf_day,
+    QA_SU_save_option_50etf_min,
     QA_SU_save_option_commodity_day,
     QA_SU_save_option_commodity_min,
     QA_SU_save_option_contract_list,
     QA_SU_save_option_day_all,
     QA_SU_save_option_min_all,
-    QA_SU_save_future_day,
-    QA_SU_save_future_min,
-    QA_SU_save_future_min_all,
-    QA_SU_save_future_day_all,
     QA_SU_save_report_calendar_day,
     QA_SU_save_report_calendar_his,
+    QA_SU_save_single_bond_day,
+    QA_SU_save_single_bond_min,
+    QA_SU_save_single_etf_day,
+    QA_SU_save_single_etf_min,
+    QA_SU_save_single_future_day,
+    QA_SU_save_single_future_min,
+    QA_SU_save_single_index_day,
+    QA_SU_save_single_index_min,
+    QA_SU_save_single_stock_day,
+    QA_SU_save_single_stock_min,
+    QA_SU_save_stock_block,
+    QA_SU_save_stock_day,
     QA_SU_save_stock_divyield_day,
     QA_SU_save_stock_divyield_his,
-    QA_SU_save_bond_day,
-    QA_SU_save_single_bond_day,
-    QA_SU_save_bond_list,
-    QA_SU_save_bond_min,
-    QA_SU_save_single_bond_min
+    QA_SU_save_stock_info_tushare,
+    QA_SU_save_stock_info,
+    QA_SU_save_stock_list,
+    QA_SU_save_stock_min,
+    QA_SU_save_stock_transaction,
+    QA_SU_save_stock_xdxr
 )
 from QUANTAXIS.QASU.save_binance import QA_SU_save_binance_symbol, QA_SU_save_binance_1hour, \
     QA_SU_save_binance_1day, QA_SU_save_binance_1min, QA_SU_save_binance
@@ -249,16 +251,21 @@ class CLI(cmd.Cmd):
             命令格式: save ox: save option_contract_list/option_day/option_min/option_commodity_day/option_commodity_min \n\
             命令格式: save transaction: save stock_transaction and index_transaction (Warning: Large Disk Space Required) \n\
             ------------------------------------------------------------ \n\
+            命令格式：save stock_xdxr : 保存日除权除息数据 \n\
             命令格式：save stock_day  : 保存日线数据 \n\
             命令格式：save single_stock_day  : 保存单个股票日线数据 \n\
-            命令格式：save stock_xdxr : 保存日除权除息数据 \n\
             命令格式：save stock_min  : 保存分钟线数据 \n\
             命令格式：save single_stock_min  : 保存单个股票分钟线数据 \n\
             命令格式：save index_day  : 保存指数日线数据 \n\
+            命令格式：save single_index_day  : 保存单个指数日线数据 \n\
             命令格式：save index_min  : 保存指数分钟线数据 \n\
             命令格式：save single_index_min  : 保存单个指数分钟线数据 \n\
             命令格式：save future_day  : 保存期货日线数据 \n\
+            命令格式：save future_day_all  : 保存期货日线数据(含合约信息,不包括已经过期摘牌的合约数据) \n\
+            命令格式：save single_future_day  : 保存单个期货日线数据 \n\
             命令格式：save future_min  : 保存期货分钟线数据 \n\
+            命令格式：save future_min_all  : 保存期货分钟线数据(含合约信息,不包括已经过期摘牌的合约数据) \n\
+            命令格式：save single_future_min  : 保存单个期货分钟线数据 \n\
             命令格式：save etf_day    : 保存ETF日线数据 \n\
             命令格式：save single_etf_day    : 保存单个ETF日线数据 \n\
             命令格式：save etf_min    : 保存ET分钟数据 \n\
@@ -543,12 +550,16 @@ class CLI(cmd.Cmd):
                 QA_SU_save_option_commodity_min('tdx')
             elif len(arg) == 2 and arg[0] == 'single_stock_day':
                 QA_SU_save_single_stock_day(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_future_day':
+                QA_SU_save_single_future_day(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_index_day':
                 QA_SU_save_single_index_day(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_etf_day':
                 QA_SU_save_single_etf_day(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_stock_min':
                 QA_SU_save_single_stock_min(arg[1], 'tdx')
+            elif len(arg) == 2 and arg[0] == 'single_future_min':
+                QA_SU_save_single_future_min(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_index_min':
                 QA_SU_save_single_index_min(arg[1], 'tdx')
             elif len(arg) == 2 and arg[0] == 'single_etf_min':

--- a/QUANTAXIS/QAData/data_resample.py
+++ b/QUANTAXIS/QAData/data_resample.py
@@ -482,7 +482,7 @@ def QA_data_min_to_day(min_data, type_='1D'):
         'amount': 'sum'
     }
 
-    return data.reset_index(1).resample(
+    return min_data.reset_index(1).resample(
         type_,
         base=0,
         closed='right'

--- a/QUANTAXIS/QASU/main.py
+++ b/QUANTAXIS/QASU/main.py
@@ -122,6 +122,21 @@ def QA_SU_save_future_list(engine, client=DATABASE):
     engine = select_save_engine(engine)
     engine.QA_SU_save_future_list(client=client)
 
+def QA_SU_save_single_future_day(code, engine, client=DATABASE, paralleled=False):
+    """save single_future_day
+
+    Arguments:
+        code: stock code
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+
+    :param paralleled: 是否并行处理(default: {True})
+    """
+
+    engine = select_save_engine(engine, paralleled=paralleled)
+    engine.QA_SU_save_single_future_day(code=code, client=client)
 
 def QA_SU_save_future_day(engine, client=DATABASE):
     """save future_day
@@ -150,6 +165,18 @@ def QA_SU_save_future_day_all(engine, client=DATABASE):
     engine = select_save_engine(engine)
     engine.QA_SU_save_future_day_all(client=client)
 
+def QA_SU_save_single_future_min(code, engine, client=DATABASE):
+    """save single_future_min
+
+    Arguments:
+        engine {[type]} -- [description]
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+
+    engine = select_save_engine(engine)
+    engine.QA_SU_save_single_future_min(code=code, client=client)
 
 def QA_SU_save_future_min(engine, client=DATABASE):
     """save future_min

--- a/QUANTAXIS/QASU/save_tdx.py
+++ b/QUANTAXIS/QASU/save_tdx.py
@@ -5147,6 +5147,93 @@ def QA_SU_save_index_list(client=DATABASE, ui_log=None, ui_progress=None):
     except:
         pass
 
+def QA_SU_save_single_future_day(code : str, client=DATABASE, ui_log=None, ui_progress=None):
+    '''
+     save single_future_day
+    保存单个期货数据日线数据
+    :param client:
+    :param ui_log:  给GUI qt 界面使用
+    :param ui_progress: 给GUI qt 界面使用
+    :param ui_progress_int_value: 给GUI qt 界面使用
+    :return:
+    '''
+    coll_future_day = client.future_day
+    coll_future_day.create_index(
+        [("code",
+          pymongo.ASCENDING),
+         ("date_stamp",
+          pymongo.ASCENDING)]
+    )
+    err = []
+
+    def __saving_work(code, coll_future_day):
+        try:
+            QA_util_log_info(
+                '##JOB12 Now Saving Future_DAY==== {}'.format(str(code)),
+                ui_log
+            )
+
+            # 首选查找数据库 是否 有 这个代码的数据
+            ref = coll_future_day.find({'code': str(code)[0:4]})
+            end_date = str(now_time())[0:10]
+
+            # 当前数据库已经包含了这个代码的数据， 继续增量更新
+            # 加入这个判断的原因是因为如果股票是刚上市的 数据库会没有数据 所以会有负索引问题出现
+            if ref.count() > 0:
+
+                # 接着上次获取的日期继续更新
+                start_date = ref[ref.count() - 1]['date']
+
+                QA_util_log_info(
+                    'UPDATE_Future_DAY \n Trying updating {} from {} to {}'
+                        .format(code,
+                                start_date,
+                                end_date),
+                    ui_log
+                )
+                if start_date != end_date:
+                    coll_future_day.insert_many(
+                        QA_util_to_json_from_pandas(
+                            QA_fetch_get_future_day(
+                                str(code),
+                                QA_util_get_next_day(start_date),
+                                end_date
+                            )
+                        )
+                    )
+
+            # 当前数据库中没有这个代码的股票数据， 从1990-01-01 开始下载所有的数据
+            else:
+                start_date = '2001-01-01'
+                QA_util_log_info(
+                    'UPDATE_Future_DAY \n Trying updating {} from {} to {}'
+                        .format(code,
+                                start_date,
+                                end_date),
+                    ui_log
+                )
+                if start_date != end_date:
+                    coll_future_day.insert_many(
+                        QA_util_to_json_from_pandas(
+                            QA_fetch_get_future_day(
+                                str(code),
+                                start_date,
+                                end_date
+                            )
+                        )
+                    )
+        except Exception as error0:
+            print(error0)
+            err.append(str(code))
+
+
+    __saving_work(code, coll_future_day)
+
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS save future day ^_^', ui_log)
+    else:
+        QA_util_log_info(' ERROR CODE \n ', ui_log)
+        QA_util_log_info(err, ui_log)
 
 def QA_SU_save_future_day(client=DATABASE, ui_log=None, ui_progress=None):
     '''
@@ -5359,6 +5446,105 @@ def QA_SU_save_future_day_all(client=DATABASE, ui_log=None, ui_progress=None):
         QA_util_log_info(' ERROR CODE \n ', ui_log)
         QA_util_log_info(err, ui_log)
 
+def QA_SU_save_single_future_min(code : str, client=DATABASE, ui_log=None, ui_progress=None):
+    """save single_future_min
+
+    Keyword Arguments:
+        client {[type]} -- [description] (default: {DATABASE})
+    """
+    coll = client.future_min
+    coll.create_index(
+        [
+            ('code',
+             pymongo.ASCENDING),
+            ('time_stamp',
+             pymongo.ASCENDING),
+            ('date_stamp',
+             pymongo.ASCENDING)
+        ]
+    )
+    err = []
+
+    def __saving_work(code, coll):
+
+        QA_util_log_info(
+            '##JOB13 Now Saving Future_MIN ==== {}'.format(str(code)),
+            ui_log=ui_log
+        )
+        try:
+
+            for type in ['1min', '5min', '15min', '30min', '60min']:
+                ref_ = coll.find({'code': str(code)[0:6], 'type': type})
+                end_time = str(now_time())[0:19]
+                if ref_.count() > 0:
+                    start_time = ref_[ref_.count() - 1]['datetime']
+
+                    QA_util_log_info(
+                        '##JOB13.{} Now Saving Future {} from {} to {} =={} '
+                            .format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_future_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data[1::])
+                            )
+                else:
+                    start_time = '2015-01-01'
+
+                    QA_util_log_info(
+                        '##JOB13.{} Now Saving Future {} from {} to {} =={} '
+                            .format(
+                            ['1min',
+                             '5min',
+                             '15min',
+                             '30min',
+                             '60min'].index(type),
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        ),
+                        ui_log=ui_log
+                    )
+
+                    if start_time != end_time:
+                        __data = QA_fetch_get_future_min(
+                            str(code),
+                            start_time,
+                            end_time,
+                            type
+                        )
+                        if len(__data) > 1:
+                            coll.insert_many(
+                                QA_util_to_json_from_pandas(__data)
+                            )
+        except:
+            err.append(code)
+
+    __saving_work(code, coll)
+    if len(err) < 1:
+        QA_util_log_info('SUCCESS', ui_log=ui_log)
+    else:
+        QA_util_log_info(' ERROR CODE \n ', ui_log=ui_log)
+        QA_util_log_info(err, ui_log=ui_log)
 
 def QA_SU_save_future_min(client=DATABASE, ui_log=None, ui_progress=None):
     """save future_min


### PR DESCRIPTION
1. 增加单个期货标的日线/分钟线存储
2. 调整save命令文本提示顺序和增加若干命令提示
3. 修复分钟线采样成日线的bug

# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:



作者信息:
时间: 
