### PR TITLE
QAAcountPro中avg_price和total_frozen计算修改

### DIFF
--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -1237,7 +1237,7 @@ class QA_AccountPRO(QA_Worker):
                         (
                             self.frozen[code][str(trade_towards)]['avg_price'] *
                             self.frozen[code][str(trade_towards)]['amount']
-                        ) + abs(trade_money)
+                        ) + abs(raw_trade_money)
                     ) / (
                         self.frozen[code][str(trade_towards)]['amount'] +
                         trade_amount

--- a/QUANTAXIS/QAARP/QAAccountPro.py
+++ b/QUANTAXIS/QAARP/QAAccountPro.py
@@ -1348,7 +1348,7 @@ class QA_AccountPRO(QA_Worker):
             ] else 0
 
             try:
-                total_frozen = sum([itex.get('avg_price', 0) * itex.get('amount', 0)
+                total_frozen = sum([itex.get('money', 0) * itex.get('amount', 0)
                                     for item in self.frozen.values() for itex in item.values()])
             except Exception as e:
                 print(e)


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:
1. avg_price按照注释中的公式，应使用raw_trade_money来计算
2. total_frozen应使用sum(money*acount)

作者信息: xiongyifan
时间: 2021-05-15 17:00:47
