### PR TITLE
年化收益率的计算

### DIFF
--- a/QUANTAXIS/QAARP/QARisk.py
+++ b/QUANTAXIS/QAARP/QARisk.py
@@ -470,7 +470,7 @@ class QA_Risk():
         self.benchmark_type = market_type
 
     def calc_annualize_return(self, assets, days):
-        return round((float(assets.iloc[-1]) / float(assets.iloc[0]) - 1) / (float(days) / 250),
+        return round((float(assets.iloc[-1]) / float(assets.iloc[0]) )**(250 / float(days))-1,
                      2)
 
     def calc_profitpctchange(self, assets):


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:

年化收益率的计算。原公式为( final_day/first_day - 1 ) / year
该公式为考虑复利，一个简单的考虑。
如果模拟周期为两年，年化10%，那么第二年末的净资产应该为1.21.
然而(1.21/1-1)/2 = 10/5%.

考虑到 first_day_asset ( 1+annu_return)^year = last_day_asset
应该有 annu_return = (last_day_asset/first_day_asset)^1/year
float(assets.iloc[-1]) / float(assets.iloc[0]) )**(250 / float(days))-1

https://www.investopedia.com/terms/a/annual-return.asp

作者信息:shijie-xie
时间: 2021-06-06
