### PR TITLE
fix: 前晚更新的复权数据，最新的复权数据adj最后一天是N/A

### DIFF
--- a/QUANTAXIS/QAData/QADataStruct.py
+++ b/QUANTAXIS/QAData/QADataStruct.py
@@ -160,6 +160,7 @@ class QA_DataStruct_Stock_day(_quotation_base):
                     ).set_index(['date',
                                  'code'])
                     data = self.data.join(adj)
+                    data.fillna(value={'adj': 1}, inplace=True)
                     for col in ['open', 'high', 'low', 'close']:
                         data[col] = data[col] * data['adj']
                     # data['volume'] = data['volume'] / \
@@ -365,7 +366,7 @@ class QA_DataStruct_Stock_min(_quotation_base):
                     u = u.set_index(['date', 'code'], drop=False)
 
                     data = u.join(adj).set_index(['datetime', 'code'])
-
+                    data.fillna(value={'adj': 1}, inplace=True)
                     for col in ['open', 'high', 'low', 'close']:
                         data[col] = data[col] * data['adj']
                     # data['volume'] = data['volume'] / \


### PR DESCRIPTION
# QUANTAXIS PR 😇

感谢您对于QUANTAXIS的项目的参与~ 🛠请在此完善一下最后的信息~

## 注意

- 如果非第一次fork, 请先将quantaxis 库的内容PR进您的项目进行更新, 然后再执行对于quantaxis的pr
- 请完善[CHANGELOG](https://github.com/QUANTAXIS/QUANTAXIS/releases)再进行PR

## PR前必看

请使用如下代码对要PR的代码进行格式化:

使用以下代码来格式化
```
pip install https://github.com/google/yapf/archive/master.zip
yapf -i --style .style.yapf <file>
```

## 🛠该PR主要解决的问题🛠:

前晚更新的复权数据，最新的复权数据adj最后一天是N/A

N/A的adj暂时先用1默认处理

作者信息:
时间: 
