### PR TITLE
Fix dependency broken due to websocket-client version conflict between requirements.txt and tushare's required

### DIFF
--- a/QUANTAXIS/QAUtil/QATransform.py
+++ b/QUANTAXIS/QAUtil/QATransform.py
@@ -32,7 +32,7 @@ import pandas as pd
 def QA_util_to_json_from_pandas(data):
     """
     explanation:
-        将pandas数据转换成json格式		
+        将pandas数据转换成json格式
 
     params:
         * data ->:
@@ -52,9 +52,11 @@ def QA_util_to_json_from_pandas(data):
 
     """需要对于datetime 和date 进行转换, 以免直接被变成了时间戳"""
     if 'datetime' in data.columns:
-        data.datetime = data.datetime.apply(str)
+        # data.datetime = data.datetime.apply(str)
+        data['datetime'] = data['datetime'].astype(str)
     if 'date' in data.columns:
-        data.date = data.date.apply(str)
+        # data.date = data.date.apply(str)
+        data['date'] = data['date'].astype(str)
     return json.loads(data.to_json(orient='records'))
 
 
@@ -69,7 +71,7 @@ def QA_util_to_json_from_list(data):
 def QA_util_to_list_from_pandas(data):
     """
     explanation:
-         将pandas数据转换成列表		
+         将pandas数据转换成列表
 
     params:
         * data ->:
@@ -93,7 +95,7 @@ def QA_util_to_list_from_pandas(data):
 def QA_util_to_list_from_numpy(data):
     """
     explanation:
-        将numpy数据转换为列表		
+        将numpy数据转换为列表
 
     params:
         * data ->:
@@ -117,7 +119,7 @@ def QA_util_to_list_from_numpy(data):
 def QA_util_to_pandas_from_json(data):
     """
     explanation:
-        将json数据载入为pandas数据		
+        将json数据载入为pandas数据
 
     params:
         * data ->:
@@ -143,7 +145,7 @@ def QA_util_to_pandas_from_json(data):
 def QA_util_to_pandas_from_list(data):
     """
     explanation:
-        将列表数据转换为pandas	
+        将列表数据转换为pandas
 
     params:
         * data ->:

--- a/config/update_x.py
+++ b/config/update_x.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     QA_SU_save_stock_min('tdx')
     QA_SU_save_index_day('tdx')
     QA_SU_save_index_min('tdx')
-    QA_SU_save_etf_day('tdx') 
+    QA_SU_save_etf_day('tdx')
     QA_SU_save_etf_min('tdx')
     QA_SU_save_stock_list('tdx')
     QA_SU_save_stock_block('tdx')

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ async_timeout
 IPython
 numba
 tushare
-websocket-client
+# websocket-client
 statsmodels>=0.12.1
 scipy
 pytdx>=1.67


### PR DESCRIPTION
## 🛠该PR主要解决的问题🛠:

cmd `quantaxis` startup brokes due to a version conflict between the _requirement.txt_ and tushare's required.
Please take a look the image below
![image](https://github.com/yutiansut/QUANTAXIS/assets/14357159/525679ae-b221-434d-a2ed-0e3aef2ea2e3)
The websocket-client tushare required is `0.57.0` while the one in _requirements.txt_ didn't limit the version.

Uncommeted it will solve.


作者信息: Harold
时间: 20230623
