### PR TITLE
demjson

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ retrying
 seaborn>=0.11.1
 attrs>=17.4.0
 pyconvert>=0.6.3
-demjson>=2.2.4
 janus==0.4.0
 pyecharts_snapshot
 async_timeout

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ except:
 """
 """
 
-if sys.version_info.major != 3 or sys.version_info.minor not in [5, 6, 7, 8, 9]:
-    print('wrong version, should be 3.5/3.6/3.7/3.8 version')
+if sys.version_info.major != 3 or sys.version_info.minor not in [5, 6, 7, 8, 9, 10]:
+    print('wrong version, should be 3.5/3.6/3.7/3.8/3.9/3.10 version')
     sys.exit()
 
 with io.open('QUANTAXIS/__init__.py', 'rt', encoding='utf8') as f:


### PR DESCRIPTION
1. demjson因为使用了use_2to3，在python3.7之后无法安装。
2. 版本限制先放开到3.10，目前一直用3.9是没问题的。估计3.10会有些问题，先放开再测试。